### PR TITLE
fix github actions CI (again)

### DIFF
--- a/.github/workflows/core-validations.yml
+++ b/.github/workflows/core-validations.yml
@@ -23,7 +23,10 @@ jobs:
       run: go version
 
     - name: Install protoc
-      run: sudo apt-get install -y protobuf-compiler golang-goprotobuf-dev
+      run: sudo apt-get update && sudo apt-get upgrade -y && sudo apt-get install -y protobuf-compiler
+
+    - name: Install golang proto tools
+      run: go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
     - name: Install GRPC proto tools
       run: go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest


### PR DESCRIPTION
Initial attempt at: https://github.com/mitchwebster/botblitz/pull/41

The CI issue is due to mixing go proto v1 and v2, which are incompatible. The previous attempt downgraded some things to v1, which caused issues. This attempt upgrades everything to v2, which is much better.

The version of `protoc-gen-go` we were getting via `apt-get` was pretty old, so I switched to fetching it via the go tool.