### PR TITLE
improve/refactor shutdown of running bot containers on exit

### DIFF
--- a/pkg/cmd/engine_bootstrap.go
+++ b/pkg/cmd/engine_bootstrap.go
@@ -66,17 +66,13 @@ func main() {
 
 	// schedule cleanup to run right before the function returns
 	defer func() {
-		botEngine.CleanupAllPyGrpcServerContainers()
-		if err != nil {
-			fmt.Printf("CRITICAL!! Failed to clean after bot run %s\n", err)
+		if err := botEngine.CleanupAllPyGrpcServerContainers(); err != nil {
+			fmt.Printf("CRITICAL!! Failed to clean after bot run %v\n", err)
 		}
 	}()
 
-	err = botEngine.Run(ctx)
-	if err != nil {
-		fmt.Println("Engine failed unexpectedly")
-		fmt.Println(err)
-		os.Exit(1) // Crash hard
+	if err := botEngine.Run(ctx); err != nil {
+		fmt.Printf("Engine failed unexpectedly: %v\n", err)
 	}
 }
 

--- a/pkg/engine/DraftHandler.go
+++ b/pkg/engine/DraftHandler.go
@@ -9,16 +9,6 @@ import (
 	"github.com/mitchwebster/botblitz/pkg/gamestate"
 )
 
-func (e *BotEngine) stopAllRunningBots() {
-	fmt.Println("Cleaning up all running containers...")
-	for _, containerInfo := range e.botContainers {
-		err := e.shutDownAndCleanBotServer(containerInfo.ContainerID)
-		if err != nil {
-			fmt.Printf("Error shutting down bot container %q: %v", containerInfo.ContainerID, err)
-		}
-	}
-}
-
 func (e *BotEngine) runDraft(ctx context.Context) error {
 	err := e.initializeDraftSheet()
 	if err != nil {
@@ -34,9 +24,6 @@ func (e *BotEngine) runDraft(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
-	// Cleanup all running bots on exit
-	defer e.stopAllRunningBots()
 
 	curRound := 1
 	for curRound <= int(leagueSettings.TotalRounds) {


### PR DESCRIPTION
Re: comments on https://github.com/mitchwebster/botblitz/commit/a1c52280c77e724937ad96b520ead037b71a4ec4#r165492616

I removed the container cleanup stuff from DraftHandler.go. The best place to put it is in `main()` in `engine_bootstrap.go` where you had it before.

The reason it wasn't working before was this bit:

```go
err = botEngine.Run(ctx)
if err != nil {
    fmt.Println("Engine failed unexpectedly")
    fmt.Println(err)
    os.Exit(1) // Crash hard
}
```

The `os.Exit()` caused it to exit immediately, ignoring the `defer` statement a few lines above it that called the cleanup routine.

