### PR TITLE
Engine-driven full-season bot evaluation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ dist/*
 # (DatabaseManager defaults to ./gamestate.db). Tracked DBs live under data/.
 /gamestate.db
 /stats.db
+
+# scratch season DB used by `make evaluate-bot` (pkg/cmd/evaluate)
+/data/game_states/2999/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,10 +87,23 @@ Flags: `-game_mode`, `-year` (default 2025), `-enable_google_sheets` (default tr
 
 ## 7. Local simulation / harness
 
+Evaluation and running of bots go through the **Go engine** (the production path) so eval logic can't drift from what runs weekly; the Python CLI (`bootstrap_data`) is for **data bootstrapping only**.
+
 `harness/` + `SimulateDraft.ipynb` are the local way to test a bot's draft logic without the
 full engine. `make launch-simulator` builds the wheel, installs it, and opens the notebook +
 a Datasette browser on a dev snapshot. The harness imports `blitz_env` and takes the bot's
 `draft_player` as a parameter; other teams use `default_draft_strategy`.
+
+### Evaluating a bot (engine-driven, authoritative)
+`make evaluate-bot BOT=bots/nfl2025/<bot>.py YEAR=2025 RUNS=3` builds the
+`py_grpc_server` image, then runs the bot through the **real engine** over a full
+historical season — draft, weekly waivers + scoring, playoffs — against a baseline
+field of containerized `standard-bot` opponents, and prints where it finished. Each
+run copies `season.db` to a scratch year (2999, gitignored) so the tracked DB is
+never mutated. This is the source of truth for "is my bot good"; the Python `harness/`
+(`simulate_draft`, `score_game`, `SimulateDraft.ipynb`) remains only an interactive dev
+aid, not an evaluator. Entry: `pkg/cmd/evaluate/main.go`; season loop + standings:
+`pkg/engine/SeasonReplayHandler.go` (`ReplaySeason`, `FinalStandings`).
 
 ## 8. Verification (how to actually prove a change works)
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+BOT ?= bots/nfl2025/standard-bot.py
+YEAR ?= 2025
+RUNS ?= 1
+
 clean:
 	rm -f pkg/common/agent.pb.go
 	rm -f pkg/common/agent_grpc.pb.go
@@ -70,6 +74,11 @@ launch-simulator:
 	datasette data/archive/2025/gamestate.db --host 127.0.0.1 --port 8001 &
 	python3 -m webbrowser http://127.0.0.1:8001/
 	jupyter lab SimulateDraft.ipynb
+
+evaluate-bot:
+	$(MAKE) build-docker
+	DOCKER_HOST="$${DOCKER_HOST:-$$(docker context inspect -f '{{.Endpoints.docker.Host}}' 2>/dev/null)}" \
+		go run ./pkg/cmd/evaluate -bot=$(BOT) -year=$(YEAR) -runs=$(RUNS)
 
 launch-in-season-datasette:
 	pip3 install -r requirements.txt

--- a/blitz_env/models.py
+++ b/blitz_env/models.py
@@ -2,7 +2,7 @@ from sqlalchemy import create_engine, Column, Integer, String, Float, Boolean, F
 from sqlalchemy import text
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, relationship
+from sqlalchemy.orm import sessionmaker
 from typing import List
 import pandas as pd
 
@@ -25,10 +25,11 @@ class Player(Base):
     # Player status fields
     availability = Column(String, default='AVAILABLE')  # AVAILABLE, DRAFTED, ON_HOLD
     pick_chosen = Column(Integer)
-    current_bot_id = Column(String, ForeignKey('bots.id'))
-
-    # Correct relationship: points to Bot.players
-    bot = relationship("Bot", back_populates="players")
+    # Plain column, intentionally NOT a ForeignKey. The `bots` table does not exist when
+    # build-season materializes `players`, so a FK here is dangling — and it breaks the Go
+    # engine's GORM SQLite migrator, which misparses the emitted `FOREIGN KEY` clause as a
+    # column. The draft writes current_bot_id directly; no DB-level FK is needed.
+    current_bot_id = Column(String)
 
 class Bot(Base):
     __tablename__ = 'bots'
@@ -38,9 +39,6 @@ class Bot(Base):
     name = Column(String)
     owner = Column(String)
     current_waiver_priority = Column(Integer, default=0)
-
-    # Reverse side: a bot has many players
-    players = relationship("Player", back_populates="bot")
 
 class LeagueSettings(Base):
     __tablename__ = 'league_settings'

--- a/docs/superpowers/plans/2026-06-06-engine-season-eval.md
+++ b/docs/superpowers/plans/2026-06-06-engine-season-eval.md
@@ -1,0 +1,730 @@
+# Engine-driven Full-Season Bot Evaluation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Evaluate a bot by running it through the *real Go engine* over a full historical season — draft, week-over-week waivers + scoring, playoffs — against a containerized baseline field, and report where it finished; reachable with one `make evaluate-bot` command.
+
+**Architecture:** Reuse the engine's existing handlers (`runDraft`, `performWeeklyFantasyActions`, `updateWeeklyScores`, playoff/standings code). Add (1) a season-replay loop + final-standings readout in `pkg/engine`, and (2) a small `pkg/cmd/evaluate` main that builds a baseline-field league, copies the tracked `season.db` to a scratch year for isolation, runs draft → replay → standings over N runs, and prints the bot's finish. Retire the parallel Python evaluator.
+
+**Tech Stack:** Go (engine + gorm/sqlite), the existing `py_grpc_server` Docker image, Makefile.
+
+---
+
+## File Structure
+
+- **Create `pkg/engine/SeasonReplayHandler.go`** — `FinalSeasonWeek` const, `Standing` struct, `(e *BotEngine) FinalStandings()`, `(e *BotEngine) seasonChampion()`, `(e *BotEngine) ReplaySeason(ctx)`.
+- **Create `pkg/engine/SeasonReplay_integration_test.go`** — Docker-free test: fixture `season.db`, replay 17 weeks via the engine's own scoring, assert standings + champion.
+- **Modify `pkg/engine/Position.go` (or a new `pkg/engine/LeagueSettings.go`)** — exported `BuildDefaultLeagueSettings(year, numTeams uint32) *common.LeagueSettings` (shared by both mains, removing duplication).
+- **Modify `pkg/cmd/engine_bootstrap.go`** — `fetchLeagueSettings` delegates to `engine.BuildDefaultLeagueSettings` (DRY).
+- **Create `pkg/cmd/evaluate/main.go`** — eval orchestration (baseline field, scratch-year isolation, draft+replay+standings, N runs, reporting).
+- **Modify `Makefile`** — `evaluate-bot` target (builds image, then runs).
+- **Modify `CLAUDE.md`** — document engine-driven eval + the principle.
+- **Delete `harness/evaluate_bot.py`** and its test in `tests/test_claude_bot.py` (`test_claude_beats_default_at_same_slot`).
+
+Key facts the implementer must rely on (verified):
+- Engine season/scoring is **container-free**: `updateWeeklyScores(ctx, finishWeek)` reads `weekly_stats` for the current week (`GetPlayerScoresForCurrentWeek`, filters by `week` only — not year), scores the best-possible lineup (`scoreTeam`), sets results, `IncrementFantasyWeek`, and `handlePlayoffsIfNeeded`. Only the draft + weekly *waivers* use containers.
+- `initSeason` builds a **14-week** regular schedule; playoffs are weeks **15–17** (`StartingPlayoffWeek=15`, `NumPlayoffTeams=6`, `TeamsReceivingByes=2`). The week-17 playoff matchup winner is the champion.
+- `getLeaderboard(bots, GetPastMatchups(StartingPlayoffWeek))` gives regular-season ranks (W/L then points).
+- Draft + season paths are **nil-Sheets-safe** (`initializeDraftSheet`, `registerPickInSheets` no-op on nil). Pass `sheetsClient=nil`.
+- Tests in `package engine` can call **unexported** methods directly (see `SeasonDb_integration_test.go`).
+- `NewGameStateHandlerForDraft(bots, settings)` requires `data/game_states/<settings.Year>/season.db` to already exist; it seeds league-state tables and does NOT recreate players. `LoadGameStateForWeeklyFantasy(year)` reopens the same file and runs `initSeason`. Between phases, close the DB: `sqlDB, _ := handler.GetDB().DB(); sqlDB.Close()`.
+
+---
+
+## Task 1: Season-replay core + final standings (engine, Docker-free, fully tested)
+
+**Files:**
+- Create: `pkg/engine/SeasonReplayHandler.go`
+- Test: `pkg/engine/SeasonReplay_integration_test.go`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `pkg/engine/SeasonReplay_integration_test.go`. It builds an 8-team fixture where bot `"0"`'s player outscores everyone every week, replays all 17 weeks using the engine's own `updateWeeklyScores`, and asserts bot `"0"` finishes #1 and wins the championship.
+
+```go
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mitchwebster/botblitz/pkg/common"
+	"github.com/mitchwebster/botblitz/pkg/gamestate"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const replayTestYear = uint32(2996)
+
+// buildReplayFixture writes a season.db at the engine-resolved path for replayTestYear:
+// 8 QB-only players each rostered to a distinct bot, and weekly_stats for weeks 1..17 where
+// player i scores (8-i)*10 every week (so bot "0" always wins). Returns nothing; cleans up.
+func buildReplayFixture(t *testing.T) {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := filepath.Join(cwd, "data", "game_states", "2996")
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	seasonPath := filepath.Join(dir, "season.db")
+	_ = os.Remove(seasonPath)
+
+	db, err := gorm.Open(sqlite.Open(seasonPath), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.AutoMigrate(&gamestate.Player{}); err != nil {
+		t.Fatalf("migrate players: %v", err)
+	}
+	for i := 0; i < 8; i++ {
+		id := string(rune('A' + i)) // "A".."H"
+		if err := db.Create(&gamestate.Player{
+			ID: id, FullName: "P" + id, ProfessionalTeam: "FA",
+			AllowedPositions: `["QB"]`, Rank: i + 1, Availability: "AVAILABLE",
+		}).Error; err != nil {
+			t.Fatalf("insert player: %v", err)
+		}
+	}
+	if err := db.Exec(`CREATE TABLE weekly_stats (fantasypros_id TEXT, week INTEGER, FPTS REAL);`).Error; err != nil {
+		t.Fatalf("create weekly_stats: %v", err)
+	}
+	for i := 0; i < 8; i++ {
+		id := string(rune('A' + i))
+		for wk := 1; wk <= 17; wk++ {
+			if err := db.Exec(`INSERT INTO weekly_stats (fantasypros_id, week, FPTS) VALUES (?, ?, ?);`,
+				id, wk, float64((8-i)*10)).Error; err != nil {
+				t.Fatalf("seed weekly_stats: %v", err)
+			}
+		}
+	}
+	sqlDB, _ := db.DB()
+	sqlDB.Close()
+}
+
+func TestReplaySeasonProducesStandingsAndChampion(t *testing.T) {
+	buildReplayFixture(t)
+
+	bots := make([]*common.Bot, 8)
+	for i := 0; i < 8; i++ {
+		id := string(rune('0' + i)) // bot ids "0".."7"
+		bots[i] = &common.Bot{Id: id, FantasyTeamName: "T" + id, Owner: id}
+	}
+	settings := BuildDefaultLeagueSettings(replayTestYear, 8)
+	settings.SlotsPerTeam = map[string]uint32{"QB": 1}
+	settings.TotalRounds = 1
+
+	// Seed league state (bots/settings/game_status), then assign rosters: player i -> bot i.
+	draftHandler, err := gamestate.NewGameStateHandlerForDraft(bots, settings)
+	if err != nil {
+		t.Fatalf("draft handler: %v", err)
+	}
+	ddb := draftHandler.GetDB()
+	for i := 0; i < 8; i++ {
+		playerID := string(rune('A' + i))
+		botID := string(rune('0' + i))
+		if err := ddb.Exec(`UPDATE players SET current_bot_id = ?, availability = 'DRAFTED' WHERE id = ?;`,
+			botID, playerID).Error; err != nil {
+			t.Fatalf("assign roster: %v", err)
+		}
+	}
+	sqlDB, _ := ddb.DB()
+	sqlDB.Close()
+
+	seasonHandler, err := gamestate.LoadGameStateForWeeklyFantasy(replayTestYear)
+	if err != nil {
+		t.Fatalf("load season: %v", err)
+	}
+	e := NewBotEngine(seasonHandler, BotEngineSettings{GameMode: UpdateWeeklyScores}, nil, nil, nil)
+
+	// Replay scoring for the whole season (Docker-free: no waiver step).
+	ctx := context.Background()
+	for {
+		week, err := seasonHandler.GetCurrentFantasyWeek()
+		if err != nil {
+			t.Fatalf("get week: %v", err)
+		}
+		if week > FinalSeasonWeek {
+			break
+		}
+		if err := e.updateWeeklyScores(ctx, true); err != nil {
+			t.Fatalf("updateWeeklyScores week %d: %v", week, err)
+		}
+	}
+
+	standings, err := e.FinalStandings()
+	if err != nil {
+		t.Fatalf("FinalStandings: %v", err)
+	}
+	if len(standings) != 8 {
+		t.Fatalf("expected 8 standings, got %d", len(standings))
+	}
+	top := standings[0]
+	if top.BotID != "0" {
+		t.Errorf("expected bot 0 to finish first, got %s", top.BotID)
+	}
+	if top.Rank != 1 || top.Wins != 14 {
+		t.Errorf("expected bot 0 rank 1 with 14 wins, got rank %d wins %d", top.Rank, top.Wins)
+	}
+	if !top.MadePlayoffs {
+		t.Error("expected bot 0 to make the playoffs")
+	}
+	if !top.IsChampion {
+		t.Error("expected bot 0 to be champion")
+	}
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd pkg/engine && go test ./... -run TestReplaySeasonProducesStandingsAndChampion`
+Expected: compile failure — `BuildDefaultLeagueSettings`, `FinalSeasonWeek`, `FinalStandings`, `Standing` undefined. (We add `BuildDefaultLeagueSettings` in Task 1 Step 3a so this test can compile.)
+
+- [ ] **Step 3a: Add the shared league-settings builder**
+
+Create `pkg/engine/LeagueSettings.go`:
+
+```go
+package engine
+
+import common "github.com/mitchwebster/botblitz/pkg/common"
+
+// BuildDefaultLeagueSettings returns the league configuration the project uses: a
+// SUPERFLEX roster (QB, RB×2, WR×2, SUPERFLEX, FLEX, K, DST, BENCH×3), snake draft, full PPR.
+func BuildDefaultLeagueSettings(year, numTeams uint32) *common.LeagueSettings {
+	slots := map[string]uint32{
+		QB.String():        1,
+		RB.String():        2,
+		WR.String():        2,
+		SUPERFLEX.String(): 1,
+		FLEX.String():      1,
+		K.String():         1,
+		DST.String():       1,
+		BENCH.String():     3,
+	}
+	var totalRounds uint32
+	for _, v := range slots {
+		totalRounds += v
+	}
+	return &common.LeagueSettings{
+		NumTeams:           numTeams,
+		IsSnakeDraft:       true,
+		TotalRounds:        totalRounds,
+		PointsPerReception: 1.0,
+		Year:               year,
+		SlotsPerTeam:       slots,
+	}
+}
+```
+
+- [ ] **Step 3b: Implement the replay handler**
+
+Create `pkg/engine/SeasonReplayHandler.go`:
+
+```go
+package engine
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+// FinalSeasonWeek is the last scored week: a 14-week regular season plus the
+// three playoff rounds (weeks 15, 16, 17).
+const FinalSeasonWeek = 17
+
+// Standing is one team's end-of-season result.
+type Standing struct {
+	BotID        string
+	Name         string
+	Rank         uint32 // regular-season rank (1 = best record)
+	Wins         uint32
+	Losses       uint32
+	Points       float32
+	MadePlayoffs bool
+	IsChampion   bool
+}
+
+// ReplaySeason advances the loaded season to completion, running each week's waiver
+// actions (bot containers) and then scoring + finishing that week (engine code).
+func (e *BotEngine) ReplaySeason(ctx context.Context) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		week, err := e.gameStateHandler.GetCurrentFantasyWeek()
+		if err != nil {
+			return err
+		}
+		if week > FinalSeasonWeek {
+			return nil
+		}
+		fmt.Printf("\n===== Replaying fantasy week %d =====\n", week)
+		if err := e.performWeeklyFantasyActions(ctx); err != nil {
+			return err
+		}
+		if err := e.updateWeeklyScores(ctx, true); err != nil {
+			return err
+		}
+	}
+}
+
+// seasonChampion returns the bot id that won the final playoff matchup, or "" if
+// the playoffs have not produced a decided final.
+func (e *BotEngine) seasonChampion() (string, error) {
+	matchups, err := e.gameStateHandler.GetMatchupsForWeek(FinalSeasonWeek)
+	if err != nil {
+		return "", err
+	}
+	for _, m := range matchups {
+		if m.IsPlayoffMatchup && m.WinningBotID != nil {
+			return *m.WinningBotID, nil
+		}
+	}
+	return "", nil
+}
+
+// FinalStandings returns every team's regular-season placement (record + points,
+// via the engine's own leaderboard) plus playoff outcome.
+func (e *BotEngine) FinalStandings() ([]Standing, error) {
+	bots, err := e.gameStateHandler.GetBots()
+	if err != nil {
+		return nil, err
+	}
+	regularSeasonMatchups, err := e.gameStateHandler.GetPastMatchups(StartingPlayoffWeek)
+	if err != nil {
+		return nil, err
+	}
+	leaderboard := getLeaderboard(bots, regularSeasonMatchups)
+
+	championID, err := e.seasonChampion()
+	if err != nil {
+		return nil, err
+	}
+
+	standings := make([]Standing, 0, len(bots))
+	for _, b := range bots {
+		r := leaderboard[b.ID]
+		standings = append(standings, Standing{
+			BotID:        b.ID,
+			Name:         b.Name,
+			Rank:         r.Ranking,
+			Wins:         r.MatchupsWon,
+			Losses:       r.MatchupsLost,
+			Points:       r.TotalPoints,
+			MadePlayoffs: r.Ranking <= NumPlayoffTeams,
+			IsChampion:   b.ID == championID,
+		})
+	}
+	sort.Slice(standings, func(i, j int) bool { return standings[i].Rank < standings[j].Rank })
+	return standings, nil
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd pkg/engine && go test ./... -run TestReplaySeasonProducesStandingsAndChampion -v`
+Expected: PASS. (Bot "0" outscores all opponents every week → 14-0 regular season → #1 seed → wins the bracket → champion.)
+
+- [ ] **Step 5: Run the whole engine test suite (no regressions)**
+
+Run: `cd pkg/engine && go test ./...`
+Expected: PASS (existing draft/weekly/playoff/season tests still green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pkg/engine/SeasonReplayHandler.go pkg/engine/LeagueSettings.go pkg/engine/SeasonReplay_integration_test.go
+git commit -m "feat(engine): season replay loop + final standings
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: DRY the league settings in the existing bootstrap
+
+**Files:**
+- Modify: `pkg/cmd/engine_bootstrap.go` (function `fetchLeagueSettings`, ~lines 324-350)
+
+- [ ] **Step 1: Replace the body of `fetchLeagueSettings` to delegate**
+
+Replace the whole `fetchLeagueSettings` function in `pkg/cmd/engine_bootstrap.go` with:
+
+```go
+func fetchLeagueSettings(year uint32, numTeams uint32) *common.LeagueSettings {
+	return engine.BuildDefaultLeagueSettings(year, numTeams)
+}
+```
+
+(Leave its call sites unchanged.)
+
+- [ ] **Step 2: Verify it builds and the engine still drafts**
+
+Run: `go build ./...`
+Expected: builds cleanly.
+
+Run: `cd pkg/engine && go test ./...`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/cmd/engine_bootstrap.go
+git commit -m "refactor(engine): share BuildDefaultLeagueSettings between mains
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Evaluation command (baseline field + scratch-year isolation + N runs)
+
+**Files:**
+- Create: `pkg/cmd/evaluate/main.go`
+
+This is its own `package main` (separate directory so it does not collide with `engine_bootstrap.go`). It cannot run headlessly without Docker, so it is verified by `go build`/`go vet` here; the e2e is owner-run in Task 4.
+
+- [ ] **Step 1: Write the command**
+
+Create `pkg/cmd/evaluate/main.go`:
+
+```go
+// Command evaluate runs a bot through the real engine over a full historical season
+// against a baseline field, and reports where it finished. It never mutates the tracked
+// season.db: each run copies it to a scratch year the engine then drafts/replays against.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	common "github.com/mitchwebster/botblitz/pkg/common"
+	"github.com/mitchwebster/botblitz/pkg/engine"
+	gamestate "github.com/mitchwebster/botblitz/pkg/gamestate"
+)
+
+var (
+	botPath      = flag.String("bot", "bots/nfl2025/claude_bot.py", "path to the bot under test")
+	baselinePath = flag.String("baseline", "bots/nfl2025/standard-bot.py", "path to the baseline opponent bot")
+	dataYear     = flag.Int("year", 2025, "season whose data (season.db) to evaluate against")
+	numTeams     = flag.Int("teams", 14, "number of teams in the league")
+	runs         = flag.Int("runs", 1, "number of independent season simulations")
+)
+
+// scratchYear is a throwaway season the engine drafts/replays against so the tracked
+// season.db is never mutated. weekly_stats are matched by week (not year), so copying the
+// real data here preserves scoring.
+const scratchYear = uint32(2999)
+
+func main() {
+	flag.Parse()
+
+	finishes := make([]int, 0, *runs)
+	champs := 0
+	playoffApps := 0
+
+	for run := 1; run <= *runs; run++ {
+		fmt.Printf("\n######## EVALUATION RUN %d/%d ########\n", run, *runs)
+		standings, err := runOneSeason(context.Background())
+		if err != nil {
+			fmt.Printf("run %d failed: %v\n", run, err)
+			os.Exit(1)
+		}
+		for i, s := range standings {
+			if s.BotID == botUnderTestID {
+				finishes = append(finishes, i+1)
+				if s.IsChampion {
+					champs++
+				}
+				if s.MadePlayoffs {
+					playoffApps++
+				}
+				fmt.Printf("\n>>> %s finished #%d (%d-%d, %.1f pts, champion=%v)\n",
+					*botPath, i+1, s.Wins, s.Losses, s.Points, s.IsChampion)
+			}
+		}
+	}
+
+	n := len(finishes)
+	if n == 0 {
+		fmt.Println("No finishes recorded.")
+		return
+	}
+	sum := 0
+	worst := 0
+	for _, f := range finishes {
+		sum += f
+		if f > worst {
+			worst = f
+		}
+	}
+	fmt.Printf("\n======== %s vs %d-team baseline field over %d run(s) ========\n",
+		*botPath, *numTeams, n)
+	fmt.Printf("avg finish     : %.2f  (neutral = %.2f)\n", float64(sum)/float64(n), float64(*numTeams+1)/2)
+	fmt.Printf("championships  : %d/%d\n", champs, n)
+	fmt.Printf("playoff apps   : %d/%d\n", playoffApps, n)
+	fmt.Printf("worst finish   : #%d\n", worst)
+}
+
+const botUnderTestID = "0"
+
+func runOneSeason(ctx context.Context) ([]engine.Standing, error) {
+	if err := resetScratchSeasonDB(uint32(*dataYear)); err != nil {
+		return nil, err
+	}
+
+	bots, srcMap := buildLeague()
+	settings := engine.BuildDefaultLeagueSettings(scratchYear, uint32(*numTeams))
+
+	// ---- Draft phase (containers) ----
+	draftHandler, err := gamestate.NewGameStateHandlerForDraft(bots, settings)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := draftHandler.GetBotsInRandomOrder(); err != nil {
+		return nil, err
+	}
+	draftEngine := engine.NewBotEngine(
+		draftHandler,
+		engine.BotEngineSettings{GameMode: engine.Draft},
+		nil, srcMap, map[string][]string{},
+	)
+	if err := draftEngine.Run(ctx); err != nil {
+		draftEngine.CleanupAllPyGrpcServerContainers()
+		return nil, err
+	}
+	if err := draftEngine.CleanupAllPyGrpcServerContainers(); err != nil {
+		return nil, err
+	}
+	if sqlDB, derr := draftHandler.GetDB().DB(); derr == nil {
+		sqlDB.Close()
+	}
+
+	// ---- Season replay phase (containers for waivers + engine scoring) ----
+	seasonHandler, err := gamestate.LoadGameStateForWeeklyFantasy(scratchYear)
+	if err != nil {
+		return nil, err
+	}
+	seasonEngine := engine.NewBotEngine(
+		seasonHandler,
+		engine.BotEngineSettings{GameMode: engine.PerformWeeklyFantasyActions},
+		nil, srcMap, map[string][]string{},
+	)
+	replayErr := seasonEngine.ReplaySeason(ctx)
+	seasonEngine.CleanupAllPyGrpcServerContainers()
+	if replayErr != nil {
+		return nil, replayErr
+	}
+	return seasonEngine.FinalStandings()
+}
+
+// buildLeague returns the bot configs (id "0" = bot under test, rest baseline) plus a
+// source-code map keyed by bot id.
+func buildLeague() ([]*common.Bot, map[string][]byte) {
+	bots := make([]*common.Bot, *numTeams)
+	srcMap := make(map[string][]byte)
+
+	botSrc := mustRead(*botPath)
+	baselineSrc := mustRead(*baselinePath)
+
+	for i := 0; i < *numTeams; i++ {
+		id := fmt.Sprintf("%d", i)
+		if i == 0 {
+			bots[i] = &common.Bot{Id: id, SourceType: common.Bot_LOCAL, SourcePath: enginePath(*botPath),
+				Owner: "Candidate", FantasyTeamName: "Candidate"}
+			srcMap[id] = botSrc
+		} else {
+			bots[i] = &common.Bot{Id: id, SourceType: common.Bot_LOCAL, SourcePath: enginePath(*baselinePath),
+				Owner: fmt.Sprintf("Baseline%d", i), FantasyTeamName: fmt.Sprintf("Baseline%d", i)}
+			srcMap[id] = baselineSrc
+		}
+	}
+	return bots, srcMap
+}
+
+// enginePath converts a repo-relative path ("bots/nfl2025/x.py") to the leading-slash form
+// the engine's BuildLocalAbsolutePath expects ("/bots/nfl2025/x.py").
+func enginePath(p string) string {
+	if len(p) > 0 && p[0] == '/' {
+		return p
+	}
+	return "/" + p
+}
+
+func mustRead(p string) []byte {
+	abs, err := common.BuildLocalAbsolutePath(enginePath(p))
+	if err != nil {
+		fmt.Printf("cannot resolve %s: %v\n", p, err)
+		os.Exit(1)
+	}
+	b, err := os.ReadFile(abs)
+	if err != nil {
+		fmt.Printf("cannot read %s: %v\n", abs, err)
+		os.Exit(1)
+	}
+	return b
+}
+
+// resetScratchSeasonDB copies data/game_states/<dataYear>/season.db to
+// data/game_states/<scratchYear>/season.db so each run starts from a pristine, undrafted
+// season without mutating the tracked file.
+func resetScratchSeasonDB(dataYear uint32) error {
+	// Resolve via BuildLocalAbsolutePath (the same repo-root join the engine uses for
+	// bot SourcePath), passing leading-slash repo-relative paths.
+	src, err := common.BuildLocalAbsolutePath(fmt.Sprintf("/data/game_states/%d/season.db", dataYear))
+	if err != nil {
+		return err
+	}
+	dst, err := common.BuildLocalAbsolutePath(fmt.Sprintf("/data/game_states/%d/season.db", scratchYear))
+	if err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(src); err != nil {
+		return fmt.Errorf("source season.db not found at %s (run build-season): %w", src, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), os.ModePerm); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}
+```
+
+- [ ] **Step 2: Verify it compiles and vets**
+
+Run: `go build ./...`
+Expected: builds cleanly (the new `pkg/cmd/evaluate` main + everything else).
+
+Run: `go vet ./pkg/cmd/evaluate/...`
+Expected: no findings.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pkg/cmd/evaluate/main.go
+git commit -m "feat(eval): engine-driven season evaluation command
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Makefile target, docs, and retire the Python proxy
+
+**Files:**
+- Modify: `Makefile`
+- Modify: `CLAUDE.md`
+- Delete: `harness/evaluate_bot.py`
+- Modify: `tests/test_claude_bot.py` (remove `test_claude_beats_default_at_same_slot`)
+
+- [ ] **Step 1: Add the Makefile target**
+
+Append to `Makefile` (use a TAB-indented recipe; mirror existing targets' style):
+
+```makefile
+evaluate-bot:
+	$(MAKE) build-docker
+	go run ./pkg/cmd/evaluate -bot=$(BOT) -year=$(YEAR) -runs=$(RUNS)
+```
+
+With defaults so a bare `make evaluate-bot` works, add near the top of the Makefile (after any existing variable defaults):
+
+```makefile
+BOT ?= bots/nfl2025/claude_bot.py
+YEAR ?= 2025
+RUNS ?= 1
+```
+
+- [ ] **Step 2: Remove the Python evaluator and its test**
+
+Run:
+```bash
+git rm harness/evaluate_bot.py
+```
+
+Edit `tests/test_claude_bot.py`: delete the entire `test_claude_beats_default_at_same_slot` function (it imports `harness.evaluate_bot`, which no longer exists).
+
+Run: `PYTHONPATH=. python3 -m pytest tests/test_claude_bot.py -q`
+Expected: PASS (the remaining claude_bot unit tests are unaffected).
+
+- [ ] **Step 3: Document in CLAUDE.md**
+
+In `CLAUDE.md` §7 (Local simulation / harness) add a subsection:
+
+```markdown
+### Evaluating a bot (engine-driven, authoritative)
+`make evaluate-bot BOT=bots/nfl2025/<bot>.py YEAR=2025 RUNS=3` builds the
+`py_grpc_server` image, then runs the bot through the **real engine** over a full
+historical season — draft, weekly waivers + scoring, playoffs — against a baseline
+field of `standard-bot` opponents (all containerized), and prints where it finished.
+It copies `season.db` to a scratch year (2999) per run, so the tracked DB is never
+mutated. This is the source of truth for "is my bot good"; the Python `harness/`
+(`simulate_draft`, `score_game`, `SimulateDraft.ipynb`) remains only an interactive
+dev aid, not an evaluator. Entry: `pkg/cmd/evaluate/main.go`;
+season loop + standings: `pkg/engine/SeasonReplayHandler.go`.
+```
+
+Also add a one-line principle to §1 or §9: "Evaluation/running goes through the Go engine (the production path); the Python CLI (`bootstrap_data`) is for data bootstrapping only."
+
+- [ ] **Step 4: Verify build + tests**
+
+Run: `go build ./... && cd pkg/engine && go test ./...`
+Expected: builds; engine tests PASS.
+
+Run: `PYTHONPATH=. python3 -m pytest tests/test_claude_bot.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Makefile CLAUDE.md tests/test_claude_bot.py
+git commit -m "feat(eval): make evaluate-bot target + docs; retire python evaluator
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Owner-run end-to-end validation (manual, documented)
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full evaluation**
+
+Run: `make evaluate-bot BOT=bots/nfl2025/claude_bot.py YEAR=2025 RUNS=3`
+Expected: builds the image, runs 3 full seasons (draft + 17 weeks of waivers/scoring + playoffs) of claude_bot vs a 13-team `standard-bot` field, and prints per-run finishes + an aggregate (avg finish, championships, playoff apps, worst finish). This requires a working Docker daemon and is heavy (14 containers × draft + 17 weeks).
+
+- [ ] **Step 2: Record results**
+
+Note the aggregate in the final report. If a run errors inside a container, capture stderr (run with the engine's verbose logging if needed) and treat as a real finding (systematic-debugging), not a reason to weaken the eval.
+
+---
+
+## Notes for the implementer
+
+- **Do not** modify bot-facing APIs, the proto, or other bots.
+- The engine season/scoring path is container-free; only draft + weekly waivers use Docker. Task 1's test deliberately drives `updateWeeklyScores` directly (no waivers) so it needs no Docker.
+- `weekly_stats` is matched by **week only**, so copying the real `season.db` to a scratch year preserves scoring — that is what keeps each eval run isolated and the tracked DB pristine.
+- Keep `harness/simulate_draft.py`, `harness/score_game.py`, and `SimulateDraft.ipynb` — they are still useful interactive aids; only `harness/evaluate_bot.py` (the parallel evaluator) is retired.

--- a/docs/superpowers/specs/2026-06-06-engine-season-eval-design.md
+++ b/docs/superpowers/specs/2026-06-06-engine-season-eval-design.md
@@ -1,0 +1,133 @@
+# Engine-driven full-season bot evaluation
+
+Date: 2026-06-06
+Status: Approved (design) — pending spec review
+
+## Why
+
+Evaluating `claude_bot` required writing `harness/evaluate_bot.py`, which re-implements
+draft order (`simulate_draft`), lineup scoring (`score_game`), and a finish metric — a
+**parallel implementation** of logic the Go engine already runs for real every week. A bot
+that looks good against that Python model may still behave wrong in the engine. The fix
+(owner's direction): **evaluation runs through the Go engine**, the Python CLI is for data
+**bootstrapping only**, and the parallel Python eval/scoring is retired.
+
+A full season is not just a draft — rosters change weekly via **waiver add/drops**. So the
+replay must run the bots' weekly actions too, which means the eval exercises BOTH
+`draft_player` and `perform_weekly_fantasy_actions` through the real engine.
+
+## What the engine already provides (reused as-is)
+
+- **Draft**: `runDraft` runs each bot in its container, validates picks, writes rosters to
+  `season.db` (`DraftHandler.go`, `ContainerHandler.go`).
+- **Weekly actions**: `performWeeklyFantasyActions` → `performFAABAddDrop` runs each bot's
+  container and applies waiver claims (`WeeklyFantasyHandler.go`).
+- **Scoring**: `updateWeeklyScores(finishWeek)` reads that week's `weekly_stats`, computes the
+  best-possible lineup per team (`scoreTeam`, greedy most-specific-slot-first — identical to
+  what the Python `score_game` duplicated), sets match results, advances the week
+  (`IncrementFantasyWeek`), and builds/advances playoffs (`EndOfWeekHandler.go`,
+  `PlayoffHandler.go`).
+- **Standings**: `getLeaderboard(bots, pastMatchups)` → W/L + total points ranking;
+  `initSeason` builds a 14-week round-robin; playoffs run weeks 15–17 (`NumPlayoffTeams=6`,
+  2 byes); the final playoff matchup winner is the champion.
+
+The engine drives one week per invocation in production (via scheduled CI). The eval simply
+**loops those same handlers** over the historical weeks already present in `season.db`.
+
+## Design
+
+### Components
+
+1. **`pkg/engine/SeasonReplayHandler.go`** (new)
+   - `func (e *BotEngine) ReplaySeason(ctx) error` — for week = current..final:
+     `performWeeklyFantasyActions(ctx)` then `updateWeeklyScores(ctx, finishWeek=true)`. Stops
+     after the playoff final (week 17). Pure orchestration over existing methods.
+   - `func (e *BotEngine) FinalStandings() ([]Standing, error)` — regular-season leaderboard
+     (`getLeaderboard` over weeks 1..14) plus playoff result (champion = winner of the last
+     playoff matchup). `Standing{BotID, Name, Rank, Wins, Losses, Points, MadePlayoffs,
+     PlayoffResult}`.
+
+2. **`pkg/cmd/evaluate/main.go`** (new, separate `main` package so it doesn't collide with
+   `engine_bootstrap.go`)
+   - Flags: `-bot` (path to the bot-under-test source, e.g. `bots/nfl2025/claude_bot.py`),
+     `-year` (default 2025), `-runs` (default 1), `-baseline` (path to the baseline opponent
+     source, default `bots/nfl2025/standard-bot.py`), `-slot` (optional fixed draft slot;
+     default randomized as the engine already does).
+   - Builds the league: 1 bot-under-test + (NumTeams-1) bots all pointing at the baseline
+     source; **no env files** (baseline + claude_bot need none). Sheets disabled.
+   - Per run: `NewGameStateHandlerForDraft` → `runDraft` → `LoadGameStateForWeeklyFantasy`
+     → `ReplaySeason` → `FinalStandings`; records the bot-under-test's finish. Cleans up
+     containers (`CleanupAllPyGrpcServerContainers`).
+   - Prints per-run finish + an aggregate summary over `-runs` (avg finish, championships,
+     playoff rate).
+
+3. **Baseline field**: `(NumTeams-1)` copies of `standard-bot.py`, distinct bot IDs, same
+   source. Reproducible, secret-free, no other-author flakiness.
+
+4. **Makefile**: `evaluate-bot` target — **self-contained**: first runs `build-docker`
+   (so the `py_grpc_server` image the containers need is freshly built and ready), then
+   `go run ./pkg/cmd/evaluate -bot=$(BOT) -year=$(YEAR) -runs=$(RUNS)`. One command does
+   everything end to end.
+
+5. **Retire the Python proxy**: delete `harness/evaluate_bot.py` and its test
+   (`test_claude_beats_default_at_same_slot`); the engine path is now authoritative. Keep
+   `harness/simulate_draft.py` + `SimulateDraft.ipynb` (interactive single-draft viz) and
+   `score_game.py` (DB inspector) as dev aids, but they are no longer the evaluator.
+
+6. **Docs**: CLAUDE.md §7/§8 — document `make evaluate-bot` as the way to evaluate a bot, and
+   state the principle (engine = source of truth for running/evaluation; Python CLI =
+   data bootstrap).
+
+### Data flow per run
+
+```
+build league (claude_bot + 13× standard-bot, sheets off, no envs)
+  -> NewGameStateHandlerForDraft -> runDraft           [containers]
+  -> LoadGameStateForWeeklyFantasy (initSeason)
+  -> ReplaySeason: for wk 1..17 {
+         performWeeklyFantasyActions                    [containers]
+         updateWeeklyScores(finishWeek=true)            [pure DB: score, results, playoffs]
+     }
+  -> FinalStandings -> record claude_bot's finish
+  -> CleanupAllPyGrpcServerContainers
+```
+
+### Realities / decisions
+
+- **Docker every week** (waivers). Heavier than a draft-only check, but it is the production
+  path and also evaluates the weekly logic. Acceptable.
+- **Field = baseline** (decided): bot-under-test + copies of `standard-bot.py`. No env files.
+- **No lineup-setting action exists** in the engine — scoring is always best-possible from the
+  roster — so weekly bot involvement is waivers only.
+- **Randomness**: draft order (`GetBotsInRandomOrder`) and `initSeason` matchups use RANDOM,
+  so each run is one sample; `-runs` aggregates. (A fixed `-slot` reduces draft-order variance
+  for A/B comparisons.)
+- **Future-week peeking** (known caveat, deferred): a historical `season.db` holds all 17
+  weeks, so a misbehaving bot could query future `weekly_stats` mid-replay. Honest bots query
+  only the current week. A future enhancement can hide weeks > current during replay.
+
+## Decomposition (implementation order)
+
+- **Slice 1 — Season replay core + standings (no Docker; fully Go-testable).**
+  `ReplaySeason` (the `updateWeeklyScores` loop) + `FinalStandings`. Tested with a fixture
+  `season.db` (pre-set rosters + multi-week `weekly_stats`, extending
+  `SeasonDb_integration_test.go`): the higher-scoring roster finishes first, playoffs progress
+  weeks 15–17, a champion is crowned. *(Replays scoring without the waiver step, which is what
+  is unit-testable without containers.)*
+- **Slice 2 — Eval orchestration + baseline field.** `pkg/cmd/evaluate/main.go` (league build,
+  draft, full replay incl. `performWeeklyFantasyActions`, standings, repetitions, reporting).
+- **Slice 3 — Makefile target + CLAUDE.md docs + retire Python `evaluate_bot.py`.**
+
+## Verification
+
+- **Go tests** (`go test ./pkg/engine/...`): Slice 1 replay/standings over the fixture DB.
+- **Compile**: `go build ./...` for the new cmd.
+- **End-to-end** (owner-run; builds the image itself): `make evaluate-bot
+  BOT=bots/nfl2025/claude_bot.py YEAR=2025 RUNS=3` → builds `py_grpc_server`, then runs
+  claude_bot's finish vs a baseline field through the real engine. *(Full e2e is not runnable
+  in CI/this session — it needs the Docker build + 14 containers × 17 weeks; Slice 1 is.)*
+
+## Out of scope
+
+- Real-league field (kept behind a future flag), trades, hiding future weeks, parallelizing
+  runs, and any change to bot-facing APIs.

--- a/pkg/cmd/engine_bootstrap.go
+++ b/pkg/cmd/engine_bootstrap.go
@@ -322,31 +322,7 @@ func fetchBotList() []*common.Bot {
 }
 
 func fetchLeagueSettings(year uint32, numTeams uint32) *common.LeagueSettings {
-	playerslots := make(map[string]uint32)
-	playerslots[engine.QB.String()] = 1
-	playerslots[engine.RB.String()] = 2
-	playerslots[engine.WR.String()] = 2
-	playerslots[engine.SUPERFLEX.String()] = 1
-	playerslots[engine.FLEX.String()] = 1
-	playerslots[engine.K.String()] = 1
-	playerslots[engine.DST.String()] = 1
-	playerslots[engine.BENCH.String()] = 3
-
-	total_rounds := uint32(0)
-	for _, v := range playerslots {
-		total_rounds += v
-	}
-
-	settings := common.LeagueSettings{
-		NumTeams:           numTeams,
-		IsSnakeDraft:       true,
-		TotalRounds:        uint32(total_rounds),
-		PointsPerReception: 1.0,
-		Year:               uint32(year),
-		SlotsPerTeam:       playerslots,
-	}
-
-	return &settings
+	return engine.BuildDefaultLeagueSettings(year, numTeams)
 }
 
 func getSourceCodeMap(bots []*common.Bot) (map[string][]byte, error) {

--- a/pkg/cmd/evaluate/main.go
+++ b/pkg/cmd/evaluate/main.go
@@ -1,0 +1,227 @@
+// Command evaluate runs a bot through the real engine over a full historical season
+// against a baseline field, and reports where it finished. It never mutates the tracked
+// season.db: each run copies it to a scratch year the engine then drafts/replays against.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	common "github.com/mitchwebster/botblitz/pkg/common"
+	"github.com/mitchwebster/botblitz/pkg/engine"
+	gamestate "github.com/mitchwebster/botblitz/pkg/gamestate"
+)
+
+var (
+	botPath      = flag.String("bot", "bots/nfl2025/standard-bot.py", "path to the bot under test")
+	baselinePath = flag.String("baseline", "bots/nfl2025/standard-bot.py", "path to the baseline opponent bot")
+	dataYear     = flag.Int("year", 2025, "season whose data (season.db) to evaluate against")
+	numTeams     = flag.Int("teams", 14, "number of teams in the league")
+	runs         = flag.Int("runs", 1, "number of independent season simulations")
+)
+
+// scratchYear is a throwaway season the engine drafts/replays against so the tracked
+// season.db is never mutated. weekly_stats are matched by week (not year), so copying the
+// real data here preserves scoring.
+const scratchYear = uint32(2999)
+
+const botUnderTestID = "0"
+
+func main() {
+	flag.Parse()
+	defer cleanupScratch()
+
+	finishes := make([]int, 0, *runs)
+	champs := 0
+	playoffApps := 0
+
+	for run := 1; run <= *runs; run++ {
+		fmt.Printf("\n######## EVALUATION RUN %d/%d ########\n", run, *runs)
+		standings, err := runOneSeason(context.Background())
+		if err != nil {
+			fmt.Printf("run %d failed: %v\n", run, err)
+			os.Exit(1)
+		}
+		for i, s := range standings {
+			if s.BotID == botUnderTestID {
+				finishes = append(finishes, i+1)
+				if s.IsChampion {
+					champs++
+				}
+				if s.MadePlayoffs {
+					playoffApps++
+				}
+				fmt.Printf("\n>>> %s finished #%d (%d-%d, %.1f pts, champion=%v)\n",
+					*botPath, i+1, s.Wins, s.Losses, s.Points, s.IsChampion)
+			}
+		}
+	}
+
+	n := len(finishes)
+	if n == 0 {
+		fmt.Println("No finishes recorded.")
+		return
+	}
+	sum := 0
+	worst := 0
+	for _, f := range finishes {
+		sum += f
+		if f > worst {
+			worst = f
+		}
+	}
+	fmt.Printf("\n======== %s vs %d-team baseline field over %d run(s) ========\n",
+		*botPath, *numTeams, n)
+	fmt.Printf("avg finish     : %.2f  (regular-season rank; neutral = %.2f)\n", float64(sum)/float64(n), float64(*numTeams+1)/2)
+	fmt.Printf("championships  : %d/%d\n", champs, n)
+	fmt.Printf("playoff apps   : %d/%d\n", playoffApps, n)
+	fmt.Printf("worst finish   : #%d\n", worst)
+}
+
+func runOneSeason(ctx context.Context) ([]engine.Standing, error) {
+	if err := resetScratchSeasonDB(uint32(*dataYear)); err != nil {
+		return nil, err
+	}
+
+	bots, srcMap := buildLeague()
+	settings := engine.BuildDefaultLeagueSettings(scratchYear, uint32(*numTeams))
+
+	// ---- Draft phase (containers) ----
+	draftHandler, err := gamestate.NewGameStateHandlerForDraft(bots, settings)
+	if err != nil {
+		return nil, err
+	}
+	// Load-bearing despite the discarded result: this seeds the handler's cached bot
+	// order that runDraft reads, so the draft order is randomized each run. Without it
+	// the draft falls back to id-ascending and bot "0" would always pick first.
+	if _, err := draftHandler.GetBotsInRandomOrder(); err != nil {
+		return nil, err
+	}
+	draftEngine := engine.NewBotEngine(
+		draftHandler,
+		engine.BotEngineSettings{GameMode: engine.Draft},
+		nil, srcMap, map[string][]string{},
+	)
+	if err := draftEngine.Run(ctx); err != nil {
+		draftEngine.CleanupAllPyGrpcServerContainers()
+		return nil, err
+	}
+	if err := draftEngine.CleanupAllPyGrpcServerContainers(); err != nil {
+		return nil, err
+	}
+	if sqlDB, derr := draftHandler.GetDB().DB(); derr == nil {
+		sqlDB.Close()
+	}
+
+	// ---- Season replay phase (containers for waivers + engine scoring) ----
+	seasonHandler, err := gamestate.LoadGameStateForWeeklyFantasy(scratchYear)
+	if err != nil {
+		return nil, err
+	}
+	seasonEngine := engine.NewBotEngine(
+		seasonHandler,
+		engine.BotEngineSettings{GameMode: engine.PerformWeeklyFantasyActions},
+		nil, srcMap, map[string][]string{},
+	)
+	replayErr := seasonEngine.ReplaySeason(ctx)
+	seasonEngine.CleanupAllPyGrpcServerContainers()
+	if replayErr != nil {
+		return nil, replayErr
+	}
+	return seasonEngine.FinalStandings()
+}
+
+// buildLeague returns the bot configs (id "0" = bot under test, rest baseline) plus a
+// source-code map keyed by bot id.
+func buildLeague() ([]*common.Bot, map[string][]byte) {
+	bots := make([]*common.Bot, *numTeams)
+	srcMap := make(map[string][]byte)
+
+	botSrc := mustRead(*botPath)
+	baselineSrc := mustRead(*baselinePath)
+
+	for i := 0; i < *numTeams; i++ {
+		id := fmt.Sprintf("%d", i)
+		if i == 0 {
+			bots[i] = &common.Bot{Id: id, SourceType: common.Bot_LOCAL, SourcePath: enginePath(*botPath),
+				Owner: "Candidate", FantasyTeamName: "Candidate"}
+			srcMap[id] = botSrc
+		} else {
+			bots[i] = &common.Bot{Id: id, SourceType: common.Bot_LOCAL, SourcePath: enginePath(*baselinePath),
+				Owner: fmt.Sprintf("Baseline%d", i), FantasyTeamName: fmt.Sprintf("Baseline%d", i)}
+			srcMap[id] = baselineSrc
+		}
+	}
+	return bots, srcMap
+}
+
+// enginePath converts a repo-relative path ("bots/nfl2025/x.py") to the leading-slash form
+// the engine's BuildLocalAbsolutePath expects ("/bots/nfl2025/x.py").
+func enginePath(p string) string {
+	if len(p) > 0 && p[0] == '/' {
+		return p
+	}
+	return "/" + p
+}
+
+func mustRead(p string) []byte {
+	abs, err := common.BuildLocalAbsolutePath(enginePath(p))
+	if err != nil {
+		fmt.Printf("cannot resolve %s: %v\n", p, err)
+		os.Exit(1)
+	}
+	b, err := os.ReadFile(abs)
+	if err != nil {
+		fmt.Printf("cannot read %s: %v\n", abs, err)
+		os.Exit(1)
+	}
+	return b
+}
+
+// resetScratchSeasonDB copies data/game_states/<dataYear>/season.db to
+// data/game_states/<scratchYear>/season.db so each run starts from a pristine, undrafted
+// season without mutating the tracked file.
+func resetScratchSeasonDB(dataYear uint32) error {
+	src, err := common.BuildLocalAbsolutePath(fmt.Sprintf("/data/game_states/%d/season.db", dataYear))
+	if err != nil {
+		return err
+	}
+	dst, err := common.BuildLocalAbsolutePath(fmt.Sprintf("/data/game_states/%d/season.db", scratchYear))
+	if err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(src); err != nil {
+		return fmt.Errorf("source season.db not found at %s (run build-season): %w", src, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), os.ModePerm); err != nil {
+		return err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+// cleanupScratch removes the scratch-year directory created for isolation.
+func cleanupScratch() {
+	dir, err := common.BuildLocalAbsolutePath(fmt.Sprintf("/data/game_states/%d", scratchYear))
+	if err != nil {
+		return
+	}
+	_ = os.RemoveAll(dir)
+}

--- a/pkg/engine/DraftMigration_integration_test.go
+++ b/pkg/engine/DraftMigration_integration_test.go
@@ -1,0 +1,91 @@
+package engine
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mitchwebster/botblitz/pkg/common"
+	"github.com/mitchwebster/botblitz/pkg/gamestate"
+)
+
+func strptr(s string) *string { return &s }
+
+// TestDraftPreservesPrebuiltPlayersData opens the *real* shipped season.db (built by the
+// Python `build-season` step) for a draft and asserts the engine neither corrupts the
+// prebuilt player data nor loses the ability to write roster assignments. A blanket
+// AutoMigrate rebuilds that Python-built `players` table (VARCHAR -> text) and the rebuild
+// NULLs out column data — so the engine must create only its league-state tables.
+func TestDraftPreservesPrebuiltPlayersData(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	// The shipped season.db lives at the repo root (two levels up from pkg/engine).
+	realDB := filepath.Join(cwd, "..", "..", "data", "game_states", "2025", "season.db")
+	if _, err := os.Stat(realDB); err != nil {
+		t.Skipf("shipped 2025 season.db not present (%v); skipping", err)
+	}
+
+	// Copy it to the engine-resolved path for a throwaway year, so the test never mutates
+	// the tracked file.
+	dir := filepath.Join(cwd, "data", "game_states", "2994")
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	if err := copyFile(realDB, filepath.Join(dir, "season.db")); err != nil {
+		t.Fatalf("copy season.db: %v", err)
+	}
+
+	// Capture a known prebuilt value to compare after the draft setup.
+	bots := []*common.Bot{
+		{Id: "0", FantasyTeamName: "A", Owner: "A"},
+		{Id: "1", FantasyTeamName: "B", Owner: "B"},
+	}
+	settings := BuildDefaultLeagueSettings(uint32(2994), 2)
+
+	handler, err := gamestate.NewGameStateHandlerForDraft(bots, settings)
+	if err != nil {
+		t.Fatalf("NewGameStateHandlerForDraft: %v", err)
+	}
+
+	// Prebuilt ranks must survive (Ja'Marr Chase, id 19788, is rank 1 in the shipped pool).
+	var rank *int
+	if err := handler.GetDB().Raw(`SELECT rank FROM players WHERE id = '19788'`).Row().Scan(&rank); err != nil {
+		t.Fatalf("scan rank: %v", err)
+	}
+	if rank == nil || *rank != 1 {
+		t.Fatalf("expected prebuilt rank 1 to survive the draft setup, got %v", rank)
+	}
+
+	// And the engine must still WRITE the draft assignment to the player row.
+	if err := handler.UpdatePlayer("19788", nil, nil, strptr("0")); err != nil {
+		t.Fatalf("UpdatePlayer (draft write): %v", err)
+	}
+	var botID *string
+	if err := handler.GetDB().Raw(`SELECT current_bot_id FROM players WHERE id = '19788'`).Row().Scan(&botID); err != nil {
+		t.Fatalf("scan current_bot_id: %v", err)
+	}
+	if botID == nil || *botID != "0" {
+		t.Fatalf("expected current_bot_id '0' written, got %v", botID)
+	}
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/pkg/engine/LeagueSettings.go
+++ b/pkg/engine/LeagueSettings.go
@@ -1,0 +1,30 @@
+package engine
+
+import common "github.com/mitchwebster/botblitz/pkg/common"
+
+// BuildDefaultLeagueSettings returns the league configuration the project uses: a
+// SUPERFLEX roster (QB, RB×2, WR×2, SUPERFLEX, FLEX, K, DST, BENCH×3), snake draft, full PPR.
+func BuildDefaultLeagueSettings(year, numTeams uint32) *common.LeagueSettings {
+	slots := map[string]uint32{
+		QB.String():        1,
+		RB.String():        2,
+		WR.String():        2,
+		SUPERFLEX.String(): 1,
+		FLEX.String():      1,
+		K.String():         1,
+		DST.String():       1,
+		BENCH.String():     3,
+	}
+	var totalRounds uint32
+	for _, v := range slots {
+		totalRounds += v
+	}
+	return &common.LeagueSettings{
+		NumTeams:           numTeams,
+		IsSnakeDraft:       true,
+		TotalRounds:        totalRounds,
+		PointsPerReception: 1.0,
+		Year:               year,
+		SlotsPerTeam:       slots,
+	}
+}

--- a/pkg/engine/SeasonReplayHandler.go
+++ b/pkg/engine/SeasonReplayHandler.go
@@ -1,0 +1,106 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"sort"
+)
+
+// FinalSeasonWeek is the last scored week. It must stay consistent with the playoff
+// schedule in PlayoffHandler.go: a 14-week regular season, then the bracket runs from
+// StartingPlayoffWeek (15) for log2(NumPlayoffTeams+TeamsReceivingByes) rounds
+// (6+2 teams => 3 rounds => weeks 15, 16, 17).
+const FinalSeasonWeek = 17
+
+// Standing is one team's end-of-season result.
+type Standing struct {
+	BotID        string
+	Name         string
+	Rank         uint32
+	Wins         uint32
+	Losses       uint32
+	Points       float32
+	MadePlayoffs bool
+	IsChampion   bool
+}
+
+// ReplaySeason advances the loaded season to completion, running each week's waiver
+// actions (bot containers) and then scoring + finishing that week (engine code).
+func (e *BotEngine) ReplaySeason(ctx context.Context) error {
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		week, err := e.gameStateHandler.GetCurrentFantasyWeek()
+		if err != nil {
+			return err
+		}
+		if week > FinalSeasonWeek {
+			return nil
+		}
+		fmt.Printf("\n===== Replaying fantasy week %d =====\n", week)
+		// Waivers require running bot containers; skip when no bot source is
+		// configured (e.g. unit tests that only exercise the scoring replay).
+		if len(e.sourceCodeCache) > 0 {
+			if err := e.performWeeklyFantasyActions(ctx); err != nil {
+				return err
+			}
+		}
+		if err := e.updateWeeklyScores(ctx, true); err != nil {
+			return err
+		}
+	}
+}
+
+// seasonChampion returns the bot id that won the final playoff matchup, or "" if
+// the playoffs have not produced a decided final.
+func (e *BotEngine) seasonChampion() (string, error) {
+	matchups, err := e.gameStateHandler.GetMatchupsForWeek(FinalSeasonWeek)
+	if err != nil {
+		return "", err
+	}
+	for _, m := range matchups {
+		if m.IsPlayoffMatchup && m.WinningBotID != nil {
+			return *m.WinningBotID, nil
+		}
+	}
+	return "", nil
+}
+
+// FinalStandings returns every team's regular-season placement (record + points,
+// via the engine's own leaderboard) plus playoff outcome.
+func (e *BotEngine) FinalStandings() ([]Standing, error) {
+	bots, err := e.gameStateHandler.GetBots()
+	if err != nil {
+		return nil, err
+	}
+	regularSeasonMatchups, err := e.gameStateHandler.GetPastMatchups(StartingPlayoffWeek)
+	if err != nil {
+		return nil, err
+	}
+	// getLeaderboard is built from the same GetBots() slice, so every bot has an entry;
+	// a missing bot would zero-value to Rank 0 (sorts first, MadePlayoffs true).
+	leaderboard := getLeaderboard(bots, regularSeasonMatchups)
+
+	championID, err := e.seasonChampion()
+	if err != nil {
+		return nil, err
+	}
+
+	standings := make([]Standing, 0, len(bots))
+	for _, b := range bots {
+		r := leaderboard[b.ID]
+		standings = append(standings, Standing{
+			BotID:        b.ID,
+			Name:         b.Name,
+			Rank:         r.Ranking,
+			Wins:         r.MatchupsWon,
+			Losses:       r.MatchupsLost,
+			Points:       r.TotalPoints,
+			MadePlayoffs: r.Ranking <= NumPlayoffTeams,
+			IsChampion:   b.ID == championID,
+		})
+	}
+	sort.Slice(standings, func(i, j int) bool { return standings[i].Rank < standings[j].Rank })
+	return standings, nil
+}

--- a/pkg/engine/SeasonReplay_integration_test.go
+++ b/pkg/engine/SeasonReplay_integration_test.go
@@ -1,0 +1,122 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mitchwebster/botblitz/pkg/common"
+	"github.com/mitchwebster/botblitz/pkg/gamestate"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+const replayTestYear = uint32(2996)
+
+func buildReplayFixture(t *testing.T) {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := filepath.Join(cwd, "data", "game_states", "2996")
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	seasonPath := filepath.Join(dir, "season.db")
+	_ = os.Remove(seasonPath)
+
+	db, err := gorm.Open(sqlite.Open(seasonPath), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if err := db.AutoMigrate(&gamestate.Player{}); err != nil {
+		t.Fatalf("migrate players: %v", err)
+	}
+	for i := 0; i < 8; i++ {
+		id := string(rune('A' + i))
+		if err := db.Create(&gamestate.Player{
+			ID: id, FullName: "P" + id, ProfessionalTeam: "FA",
+			AllowedPositions: `["QB"]`, Rank: i + 1, Availability: "AVAILABLE",
+		}).Error; err != nil {
+			t.Fatalf("insert player: %v", err)
+		}
+	}
+	if err := db.Exec(`CREATE TABLE weekly_stats (fantasypros_id TEXT, week INTEGER, FPTS REAL);`).Error; err != nil {
+		t.Fatalf("create weekly_stats: %v", err)
+	}
+	for i := 0; i < 8; i++ {
+		id := string(rune('A' + i))
+		for wk := 1; wk <= 17; wk++ {
+			if err := db.Exec(`INSERT INTO weekly_stats (fantasypros_id, week, FPTS) VALUES (?, ?, ?);`,
+				id, wk, float64((8-i)*10)).Error; err != nil {
+				t.Fatalf("seed weekly_stats: %v", err)
+			}
+		}
+	}
+	sqlDB, _ := db.DB()
+	sqlDB.Close()
+}
+
+func TestReplaySeasonProducesStandingsAndChampion(t *testing.T) {
+	buildReplayFixture(t)
+
+	bots := make([]*common.Bot, 8)
+	for i := 0; i < 8; i++ {
+		id := string(rune('0' + i))
+		bots[i] = &common.Bot{Id: id, FantasyTeamName: "T" + id, Owner: id}
+	}
+	settings := BuildDefaultLeagueSettings(replayTestYear, 8)
+	settings.SlotsPerTeam = map[string]uint32{"QB": 1}
+	settings.TotalRounds = 1
+
+	draftHandler, err := gamestate.NewGameStateHandlerForDraft(bots, settings)
+	if err != nil {
+		t.Fatalf("draft handler: %v", err)
+	}
+	ddb := draftHandler.GetDB()
+	for i := 0; i < 8; i++ {
+		playerID := string(rune('A' + i))
+		botID := string(rune('0' + i))
+		if err := ddb.Exec(`UPDATE players SET current_bot_id = ?, availability = 'DRAFTED' WHERE id = ?;`,
+			botID, playerID).Error; err != nil {
+			t.Fatalf("assign roster: %v", err)
+		}
+	}
+	sqlDB, _ := ddb.DB()
+	sqlDB.Close()
+
+	seasonHandler, err := gamestate.LoadGameStateForWeeklyFantasy(replayTestYear)
+	if err != nil {
+		t.Fatalf("load season: %v", err)
+	}
+	e := NewBotEngine(seasonHandler, BotEngineSettings{GameMode: UpdateWeeklyScores}, nil, nil, nil)
+
+	ctx := context.Background()
+	if err := e.ReplaySeason(ctx); err != nil {
+		t.Fatalf("ReplaySeason: %v", err)
+	}
+
+	standings, err := e.FinalStandings()
+	if err != nil {
+		t.Fatalf("FinalStandings: %v", err)
+	}
+	if len(standings) != 8 {
+		t.Fatalf("expected 8 standings, got %d", len(standings))
+	}
+	top := standings[0]
+	if top.BotID != "0" {
+		t.Errorf("expected bot 0 to finish first, got %s", top.BotID)
+	}
+	if top.Rank != 1 || top.Wins != 14 {
+		t.Errorf("expected bot 0 rank 1 with 14 wins, got rank %d wins %d", top.Rank, top.Wins)
+	}
+	if !top.MadePlayoffs {
+		t.Error("expected bot 0 to make the playoffs")
+	}
+	if !top.IsChampion {
+		t.Error("expected bot 0 to be champion")
+	}
+}

--- a/pkg/gamestate/handler.go
+++ b/pkg/gamestate/handler.go
@@ -435,7 +435,9 @@ func LoadGameStateForWeeklyFantasy(year uint32) (*GameStateHandler, error) {
 		)
 	}
 
-	db, err := gorm.Open(sqlite.Open(saveFileName), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(saveFileName), &gorm.Config{
+		DisableForeignKeyConstraintWhenMigrating: true,
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -567,6 +569,26 @@ func generateSchedule(botIds []string, weeks int) [][]Matchup {
 	return schedule
 }
 
+// createLeagueStateTables creates the engine-owned league-state tables when absent,
+// WITHOUT running AutoMigrate. A blanket AutoMigrate reconciles associated models —
+// including the prebuilt `players` table (via Bot.Players / WeeklyLineup.Player) — and
+// GORM's SQLite migrator rebuilds that Python-built table to change VARCHAR columns to
+// text, silently NULLing the data. Creating only the missing league-state tables (with FK
+// constraints disabled via the gorm.Config) never touches `players`. Row reads/writes on
+// players continue to work through the Player model.
+func createLeagueStateTables(db *gorm.DB) error {
+	models := []interface{}{&Bot{}, &gameStatus{}, &LeagueSettings{}, &WeeklyLineup{}, &Transaction{}}
+	for _, m := range models {
+		if db.Migrator().HasTable(m) {
+			continue
+		}
+		if err := db.Migrator().CreateTable(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func NewGameStateHandlerForDraft(bots []*common.Bot, settings *common.LeagueSettings) (*GameStateHandler, error) {
 	if len(bots) < 1 {
 		return nil, fmt.Errorf("Cannot create game for %d bots", len(bots))
@@ -589,15 +611,21 @@ func NewGameStateHandlerForDraft(bots []*common.Bot, settings *common.LeagueSett
 		)
 	}
 
-	db, err := gorm.Open(sqlite.Open(saveFileName), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(saveFileName), &gorm.Config{
+		DisableForeignKeyConstraintWhenMigrating: true,
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	// season.db already carries the `players` pool + reference tables. The engine
-	// owns only the league-state tables, so migrate just those into the existing file.
-	err = db.AutoMigrate(&Bot{}, &gameStatus{}, &LeagueSettings{}, &WeeklyLineup{}, &Transaction{})
-	if err != nil {
+	// season.db already carries the `players` pool + reference tables. The engine owns
+	// only the league-state tables, so CREATE just those (when absent). We must NOT run a
+	// blanket AutoMigrate: it reconciles associated models — including the prebuilt
+	// `players` table (via Bot.Players / WeeklyLineup.Player) — and GORM's SQLite migrator
+	// rebuilds that Python-built table to "fix" VARCHAR->text columns, which silently NULLs
+	// the data. The draft still reads/writes player ROWS through the Player model; only the
+	// schema reconciliation is skipped.
+	if err = createLeagueStateTables(db); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary
Adds a way to evaluate a bot through the **real Go engine** instead of a parallel Python harness, so eval logic can't drift from what runs week to week.

- **`make evaluate-bot BOT=bots/nfl2025/<bot>.py YEAR=2025 RUNS=n`** builds the `py_grpc_server` image, then drafts and replays a full historical season — draft → weekly waivers + scoring → playoffs — against a baseline field of containerized `standard-bot` opponents, and reports where the bot finished (avg finish, championships, playoff apps), aggregated over `RUNS`.
- Reuses the engine's own handlers (`runDraft`, `performWeeklyFantasyActions`, `updateWeeklyScores`, playoff/standings) — no re-implemented game logic. New code is just the season-replay loop + standings readout (`pkg/engine/SeasonReplayHandler.go`) and the orchestration command (`pkg/cmd/evaluate/main.go`).
- Each run copies `season.db` to a scratch year (2999, gitignored) so the tracked DB is never mutated. `evaluate-bot` resolves `DOCKER_HOST` from the active docker context (works on Docker Desktop and Linux/CI).
- `fetchLeagueSettings` now delegates to a shared `engine.BuildDefaultLeagueSettings`.

## Engine bug fix (surfaced by the eval)
Running a real season exposed a latent bug: `NewGameStateHandlerForDraft` ran a blanket `AutoMigrate` that reconciled the **Python-built `players` table** (via `Bot.Players`). GORM's SQLite migrator first choked on its dangling `FOREIGN KEY` clause, then (FK removed) rebuilt `VARCHAR`→`text` and **silently NULLed every column's data** (e.g. `rank`) — so bots read a rankless pool and crashed.

Fix: drop the dangling FK + unused relationships from `blitz_env/models.py` (the `bots` table doesn't exist when `build-season` materializes `players`), rebuild `season.db`, and create only the engine-owned league-state tables instead of migrating the prebuilt one. Row writes (draft assignments) still go through the Player model. A regression test against a real `season.db` copy fails without the fix (rank nulled) and passes with it.

## Test plan
- [x] `go test ./pkg/engine/...` — incl. a Docker-free 17-week season replay (with playoffs) and the players-corruption regression test.
- [x] `go build ./pkg/cmd/... ./pkg/engine/...`
- [x] `python3 -m pytest tests/` (13 passed, incl. the shipped-`season.db` check on the rebuilt FK-free DB).
- [x] End-to-end `make evaluate-bot` run completed a full containerized season on 2025 data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)