### PR TITLE
feat(jack_bot): dynamic team identity via get_my_bot_id

### DIFF
--- a/bots/nfl2025/jack_bot.py
+++ b/bots/nfl2025/jack_bot.py
@@ -7,12 +7,22 @@ def get_positions_to_fill(db):
     df = pd.read_sql("SELECT * FROM league_settings", db.engine)
     return json.loads(df.iloc[0]["player_slots"])
 
+def get_my_bot_id(db):
+    """Return the id of the bot the engine is currently asking to act.
+
+    The engine writes the acting bot into game_statuses.current_bot_id before
+    invoking us (each draft pick and each weekly turn), so this is the single
+    source of truth for "which team am I?" — never hardcode an id.
+    """
+    df = pd.read_sql("SELECT current_bot_id FROM game_statuses", db.engine)
+    return df.iloc[0]["current_bot_id"]
+
 def get_my_team(db):
     df = pd.read_sql("SELECT * FROM game_statuses", db.engine) # get game status
     draft_pick = df.iloc[0]["current_draft_pick"]
     print(f"Current pick is {draft_pick}")
-    
-    bot_id = df.iloc[0]["current_bot_id"]
+
+    bot_id = get_my_bot_id(db)
     queryStr = f"SELECT * FROM players where current_bot_id = '{bot_id}'"
     my_team = pd.read_sql(queryStr, db.engine) 
 
@@ -153,7 +163,7 @@ def perform_weekly_fantasy_actions() -> AttemptedFantasyActions:
         return replacement
 
     try:
-        bot_id = 8
+        bot_id = get_my_bot_id(db)
         league_year = db.get_league_settings().year
         gs = pd.read_sql("SELECT * FROM game_statuses", db.engine)
         current_week = gs.iloc[0]["current_fantasy_week"]
@@ -164,7 +174,7 @@ def perform_weekly_fantasy_actions() -> AttemptedFantasyActions:
             SELECT p.*, ws.FPTS
             FROM players p
             JOIN weekly_stats ws ON p.id = ws.fantasypros_id AND ws.week = {current_week - 1}
-            WHERE p.current_bot_id = {bot_id}
+            WHERE p.current_bot_id = '{bot_id}'
             """,
             db.engine
         )

--- a/tests/test_jack_bot.py
+++ b/tests/test_jack_bot.py
@@ -1,0 +1,47 @@
+import importlib.util
+
+from blitz_env.models import DatabaseManager, GameStatus
+
+
+def _load_jack_bot():
+    spec = importlib.util.spec_from_file_location(
+        "jack_bot", "bots/nfl2025/jack_bot.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_jack_bot_imports_cleanly():
+    # The bot must import in isolation (as it does inside the container).
+    mod = _load_jack_bot()
+    assert hasattr(mod, "get_my_bot_id")
+
+
+def test_get_my_bot_id_returns_current_acting_bot(tmp_path, monkeypatch):
+    """get_my_bot_id derives identity from game_statuses.current_bot_id, the
+    id the engine sets to whichever team it is currently asking about."""
+    scratch = tmp_path / "gamestate.db"
+    monkeypatch.setattr(DatabaseManager, "DB_URL", f"sqlite:///{scratch}")
+
+    bot = _load_jack_bot()
+
+    db = DatabaseManager()
+    try:
+        # Engine writes the acting bot here before invoking the bot each turn.
+        acting_bot_id = "bot-42"
+        db.session.add(GameStatus(current_bot_id=acting_bot_id,
+                                  current_draft_pick=1,
+                                  current_fantasy_week=3))
+        db.session.commit()
+
+        assert bot.get_my_bot_id(db) == acting_bot_id
+
+        # When the engine reassigns the acting team, the helper follows it —
+        # no hardcoded identity.
+        status = db.get_game_status()
+        status.current_bot_id = "bot-7"
+        db.session.commit()
+
+        assert bot.get_my_bot_id(db) == "bot-7"
+    finally:
+        db.close()


### PR DESCRIPTION
Closes #262

Replaces the hardcoded `bot_id = 8` in `jack_bot.py`'s weekly path with a `get_my_bot_id(db)` helper that reads `game_statuses.current_bot_id` (set by the engine to the acting team each turn).

- `get_my_bot_id(db)` derives identity from `game_statuses.current_bot_id`
- No hardcoded `bot_id` remains; both the draft (`get_my_team`) and weekly paths use the helper
- Weekly roster query now filters on the returned id
- New unit test `tests/test_jack_bot.py` verifies the helper returns the current acting bot id (and follows reassignment) and that the bot imports cleanly in isolation
- `jack_bot.py` remains a single self-contained file

🤖 Generated with [Claude Code](https://claude.com/claude-code)