### PR TITLE
feat(jack_bot): forward-looking waiver value + FAAB bid sizing (#265)

### DIFF
--- a/bots/nfl2025/jack_bot.py
+++ b/bots/nfl2025/jack_bot.py
@@ -436,6 +436,148 @@ def draft_player() -> str:
     finally:
         db.close()
 
+# ---------------------------------------------------------------------------
+# Weekly waiver valuation + FAAB bid sizing (issue #265)
+#
+# These are PURE functions: player_forward_value takes already-extracted
+# sequences (recent weekly actuals + upcoming weekly projections) plus an
+# injury status string; size_bid takes plain numbers. Neither reads the DB or
+# engine, so both are unit-tested fully offline. The weekly DB wiring that
+# feeds them (pulling trailing_actuals / projections / game_status out of
+# weekly_stats / weekly_projections / weekly_injuries) lands in #266.
+# ---------------------------------------------------------------------------
+
+# Injury game-status gates, keyed off weekly_injuries.game_status (NFL.com values
+# like 'Out', 'Doubtful', 'Questionable'). The multiplier scales a player's
+# forward value DOWN toward zero when they're unlikely to play: OUT collapses it
+# to 0 (won't play), DOUBTFUL / QUESTIONABLE get partial discounts, everything
+# else (ACTIVE / PROBABLE / None / unknown) keeps full value. Matched
+# case-insensitively so 'OUT' and 'Out' gate identically.
+INJURY_PLAY_MULTIPLIER = {
+    "OUT": 0.0,
+    "DOUBTFUL": 0.25,
+    "QUESTIONABLE": 0.75,
+    "PROBABLE": 1.0,
+    "ACTIVE": 1.0,
+}
+
+# Blend weight on trailing actuals vs. upcoming projections in forward value.
+# 0.5 = equal trust in recent production and what the projections expect next.
+FORWARD_TRAILING_WEIGHT = 0.5
+
+# Default FAAB aggressiveness when the BID_AMOUNT env var is unset. 1.0 is
+# neutral; >1 bids harder (spends a larger share of budget per upgrade), <1 is
+# more conservative. The engine injects BID_AMOUNT per-bot from bots/nfl/envs.
+DEFAULT_BID_AMOUNT = 1.0
+
+# Regular-season FAAB weeks, used to derive how much of the budget is unlocked
+# each week (the late-season reserve ramp).
+FAAB_SEASON_WEEKS = 14
+
+# Floor on the per-week spendable fraction so even very early / low-budget weeks
+# can still place a small bid instead of being capped to 1.
+MIN_SPEND_FRACTION = 0.10
+
+# Tie-break margin. League ties break toward the worse-ranked team, so to win a
+# claim as the better-ranked team we must strictly OUTBID an equal-value
+# opponent — round up and add this margin (still subject to the budget clamp).
+TIE_BREAK_MARGIN = 1
+
+
+def injury_play_multiplier(injury_status):
+    """Map an injury / game-status string to a [0, 1] play-likelihood multiplier.
+
+    Case-insensitive; None / unknown statuses keep full value (1.0). 'OUT'
+    collapses to 0.0 (player won't play)."""
+    if injury_status is None:
+        return 1.0
+    return INJURY_PLAY_MULTIPLIER.get(str(injury_status).strip().upper(), 1.0)
+
+
+def player_forward_value(trailing_actuals, projections, injury_status=None):
+    """Forward-looking weekly value: a blend of average trailing-N-week actual
+    FPTS and average next-N-week projected FPTS, gated DOWN by injury status.
+
+    PURE: ``trailing_actuals`` is an iterable of recent weekly actual FPTS,
+    ``projections`` an iterable of upcoming weekly projected FPTS (None / NaN
+    entries are ignored, empty -> 0.0), ``injury_status`` a game-status string
+    (e.g. 'OUT'/'Questionable') or None.
+
+    Monotonic in both inputs: raising any trailing actual or any projection
+    weakly increases the value (positive blend weights). Injury gating only
+    ever scales the value down (OUT -> 0)."""
+    def _avg(seq):
+        vals = [
+            float(x) for x in (seq or [])
+            if x is not None and not (isinstance(x, float) and math.isnan(x))
+        ]
+        return sum(vals) / len(vals) if vals else 0.0
+
+    trailing = _avg(trailing_actuals)
+    upcoming = _avg(projections)
+    base = (
+        FORWARD_TRAILING_WEIGHT * trailing
+        + (1.0 - FORWARD_TRAILING_WEIGHT) * upcoming
+    )
+    return base * injury_play_multiplier(injury_status)
+
+
+def _bid_aggressiveness():
+    """Read the BID_AMOUNT env var as a non-negative aggressiveness scalar,
+    falling back to DEFAULT_BID_AMOUNT when unset / unparseable."""
+    try:
+        return max(0.0, float(os.environ.get("BID_AMOUNT", DEFAULT_BID_AMOUNT)))
+    except (TypeError, ValueError):
+        return DEFAULT_BID_AMOUNT
+
+
+def size_bid(upgrade, upgrade_max, remaining_budget, week):
+    """Size a FAAB bid (int) for a waiver upgrade.
+
+    The bid is proportional to this upgrade's share of the best upgrade
+    available (``upgrade / upgrade_max``), scaled by the remaining budget and
+    the BID_AMOUNT aggressiveness scalar, then clamped:
+
+      * never below 1 (when there's any positive upgrade and budget to spend),
+      * never above ``remaining_budget``,
+      * never above a budget-reserve cap that SHRINKS when the budget is low
+        (the cap is a fraction OF the budget) or the season is early (the
+        fraction ramps from MIN_SPEND_FRACTION up to 1.0 by FAAB_SEASON_WEEKS),
+        preserving a late-season reserve.
+
+    A strictly-positive upgrade rounds UP and adds TIE_BREAK_MARGIN so we
+    clearly outbid an equal-value opponent (ties break toward the worse-ranked
+    team); the budget / reserve clamps always win over that margin.
+
+    PURE: plain numbers in, int out. No DB / engine access."""
+    budget = int(remaining_budget or 0)
+    if budget <= 0:
+        return 0
+
+    up = max(0.0, float(upgrade or 0.0))
+    up_max = float(upgrade_max or 0.0)
+    if up <= 0.0:
+        return 1  # minimal speculative bid; never drop below 1 with budget left
+
+    share = up / up_max if up_max > 0 else 1.0
+    share = min(1.0, max(0.0, share))
+
+    # Late-season reserve ramp: unlock more of the budget as the season goes on.
+    spend_fraction = max(
+        MIN_SPEND_FRACTION,
+        min(1.0, float(week or 0) / FAAB_SEASON_WEEKS),
+    )
+    # Reserve cap shrinks with low budget (fraction OF budget) and early weeks
+    # (smaller fraction). Bounded by the remaining budget.
+    cap = min(budget, max(1, int(math.ceil(budget * spend_fraction))))
+
+    raw = share * budget * _bid_aggressiveness()
+    # Round up + margin so a better-ranked team clearly outbids on a tie.
+    bid = int(math.ceil(raw)) + TIE_BREAK_MARGIN
+    # Clamp: at least 1, never over the reserve cap or the remaining budget.
+    return max(1, min(bid, cap, budget))
+
+
 def perform_weekly_fantasy_actions() -> AttemptedFantasyActions:
     db = DatabaseManager()
 

--- a/tests/test_jack_bot_waiver.py
+++ b/tests/test_jack_bot_waiver.py
@@ -1,0 +1,157 @@
+"""Offline unit tests for the forward-looking waiver value + FAAB bid sizing
+pure functions in jack_bot (issue #265).
+
+These exercise ONLY the pure functions (player_forward_value, size_bid) with
+plain inline numbers / lists — no DB, no engine, fully offline.
+"""
+import importlib.util
+
+
+def _load_jack_bot():
+    spec = importlib.util.spec_from_file_location(
+        "jack_bot", "bots/nfl2025/jack_bot.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --------------------------------------------------------------------------- #
+# player_forward_value
+# --------------------------------------------------------------------------- #
+def test_forward_value_blends_trailing_and_projections():
+    bot = _load_jack_bot()
+    # Equal trailing and projections -> value equals that common average.
+    val = bot.player_forward_value([10.0, 10.0], [10.0, 10.0])
+    assert abs(val - 10.0) < 1e-9
+    # A blend of two different averages sits strictly between them.
+    val = bot.player_forward_value([0.0, 0.0], [20.0, 20.0])
+    assert 0.0 < val < 20.0
+
+
+def test_forward_value_monotonic_in_trailing_actuals():
+    bot = _load_jack_bot()
+    low = bot.player_forward_value([5.0, 5.0], [12.0])
+    mid = bot.player_forward_value([10.0, 10.0], [12.0])
+    high = bot.player_forward_value([20.0, 20.0], [12.0])
+    assert low <= mid <= high
+    assert high > low  # strictly increasing when trailing actually rises
+
+
+def test_forward_value_monotonic_in_projections():
+    bot = _load_jack_bot()
+    low = bot.player_forward_value([10.0], [5.0, 5.0])
+    mid = bot.player_forward_value([10.0], [10.0, 10.0])
+    high = bot.player_forward_value([10.0], [20.0, 20.0])
+    assert low <= mid <= high
+    assert high > low
+
+
+def test_forward_value_out_gates_toward_zero():
+    bot = _load_jack_bot()
+    healthy = bot.player_forward_value([15.0, 15.0], [15.0, 15.0], "ACTIVE")
+    out = bot.player_forward_value([15.0, 15.0], [15.0, 15.0], "OUT")
+    assert healthy > 0
+    assert out == 0.0
+    # Case-insensitive: 'Out' gates identically to 'OUT'.
+    assert bot.player_forward_value([15.0], [15.0], "Out") == 0.0
+
+
+def test_forward_value_partial_injury_discounts_between_zero_and_full():
+    bot = _load_jack_bot()
+    full = bot.player_forward_value([12.0], [12.0], None)
+    questionable = bot.player_forward_value([12.0], [12.0], "Questionable")
+    doubtful = bot.player_forward_value([12.0], [12.0], "Doubtful")
+    out = bot.player_forward_value([12.0], [12.0], "Out")
+    assert out < doubtful < questionable < full
+    assert out == 0.0
+
+
+def test_forward_value_empty_inputs_are_safe():
+    bot = _load_jack_bot()
+    assert bot.player_forward_value([], []) == 0.0
+    # Unknown / None status keeps full value (no spurious gating).
+    assert bot.player_forward_value([10.0], [10.0], "SomethingWeird") == 10.0
+
+
+# --------------------------------------------------------------------------- #
+# size_bid
+# --------------------------------------------------------------------------- #
+def test_bid_scales_proportionally_with_upgrade():
+    bot = _load_jack_bot()
+    # Late season + large budget so neither the reserve cap nor the budget clamp
+    # binds; bids should grow with the upgrade's share of the max.
+    week = bot.FAAB_SEASON_WEEKS
+    budget = 1000
+    small = bot.size_bid(upgrade=2.0, upgrade_max=10.0, remaining_budget=budget, week=week)
+    medium = bot.size_bid(upgrade=5.0, upgrade_max=10.0, remaining_budget=budget, week=week)
+    large = bot.size_bid(upgrade=9.0, upgrade_max=10.0, remaining_budget=budget, week=week)
+    assert small < medium < large
+
+
+def test_bid_reserve_clamp_caps_early_season(monkeypatch):
+    bot = _load_jack_bot()
+    monkeypatch.delenv("BID_AMOUNT", raising=False)
+    budget = 100
+    early = bot.size_bid(upgrade=10.0, upgrade_max=10.0, remaining_budget=budget, week=1)
+    late = bot.size_bid(upgrade=10.0, upgrade_max=10.0, remaining_budget=budget, week=bot.FAAB_SEASON_WEEKS)
+    # Early-season bid is held back to preserve a late-season reserve.
+    assert early < late
+    assert early <= budget
+
+
+def test_bid_reserve_clamp_caps_low_budget():
+    bot = _load_jack_bot()
+    # A low budget shrinks the absolute reserve cap even late in the season.
+    week = bot.FAAB_SEASON_WEEKS
+    low = bot.size_bid(upgrade=10.0, upgrade_max=10.0, remaining_budget=5, week=week)
+    high = bot.size_bid(upgrade=10.0, upgrade_max=10.0, remaining_budget=500, week=week)
+    assert low < high
+    assert low <= 5
+
+
+def test_bid_never_exceeds_budget_and_never_below_one():
+    bot = _load_jack_bot()
+    # Max upgrade, tiny budget, late season: clamp to budget, still >= 1.
+    bid = bot.size_bid(upgrade=10.0, upgrade_max=10.0, remaining_budget=1, week=bot.FAAB_SEASON_WEEKS)
+    assert bid == 1
+    # Zero budget -> cannot bid.
+    assert bot.size_bid(upgrade=10.0, upgrade_max=10.0, remaining_budget=0, week=10) == 0
+    # Positive upgrade always yields at least 1 when budget remains.
+    bid = bot.size_bid(upgrade=0.01, upgrade_max=10.0, remaining_budget=50, week=1)
+    assert bid >= 1
+    # Never exceeds budget across a sweep of weeks/upgrades.
+    for week in range(1, bot.FAAB_SEASON_WEEKS + 2):
+        for up in (0.0, 1.0, 5.0, 10.0):
+            b = bot.size_bid(upgrade=up, upgrade_max=10.0, remaining_budget=30, week=week)
+            assert 0 <= b <= 30
+
+
+def test_bid_outbids_on_tie_margin():
+    bot = _load_jack_bot()
+    # A strictly-positive upgrade rounds up + adds the tie-break margin so a
+    # better-ranked team clearly outbids an equal-value opponent.
+    week = bot.FAAB_SEASON_WEEKS
+    bid = bot.size_bid(upgrade=5.0, upgrade_max=10.0, remaining_budget=1000, week=week)
+    # raw share = 0.5 -> 0.5 * 1000 = 500; ceil + margin = 501.
+    assert bid == 501
+
+
+def test_bid_amount_env_scales_aggressiveness(monkeypatch):
+    bot = _load_jack_bot()
+    week = bot.FAAB_SEASON_WEEKS
+    budget = 1000
+    monkeypatch.setenv("BID_AMOUNT", "1.0")
+    neutral = bot.size_bid(upgrade=3.0, upgrade_max=10.0, remaining_budget=budget, week=week)
+    monkeypatch.setenv("BID_AMOUNT", "2.0")
+    aggressive = bot.size_bid(upgrade=3.0, upgrade_max=10.0, remaining_budget=budget, week=week)
+    monkeypatch.setenv("BID_AMOUNT", "0.5")
+    passive = bot.size_bid(upgrade=3.0, upgrade_max=10.0, remaining_budget=budget, week=week)
+    assert passive < neutral < aggressive
+
+
+def test_bid_amount_env_default_when_unset(monkeypatch):
+    bot = _load_jack_bot()
+    monkeypatch.delenv("BID_AMOUNT", raising=False)
+    # Unset env falls back to DEFAULT_BID_AMOUNT (no crash, neutral sizing).
+    bid = bot.size_bid(upgrade=3.0, upgrade_max=10.0, remaining_budget=1000, week=bot.FAAB_SEASON_WEEKS)
+    assert bid >= 1


### PR DESCRIPTION
Closes #265

Adds two pure functions to `bots/nfl2025/jack_bot.py` plus offline unit tests.

## `player_forward_value(trailing_actuals, projections, injury_status)`
- Blends average trailing-N-week actual FPTS with average upcoming-N-week projected FPTS (`FORWARD_TRAILING_WEIGHT = 0.5`), monotonic in both inputs.
- Gates value DOWN by injury game-status (`INJURY_PLAY_MULTIPLIER`): `OUT -> 0`, `DOUBTFUL -> 0.25`, `QUESTIONABLE -> 0.75`, else full. Case-insensitive; None/unknown keep full value.

## `size_bid(upgrade, upgrade_max, remaining_budget, week)`
- Proportional to `upgrade / upgrade_max`, scaled by remaining budget and the `BID_AMOUNT` env aggressiveness scalar (default `1.0`).
- Clamped to >= 1, to <= remaining budget, and to a budget-reserve cap that shrinks for low budget / early weeks (late-season reserve ramp).
- Rounds up + adds a tie-break margin so a better-ranked team clearly outbids equal-value opponents (ties break toward the worse-ranked team).

## Tests
`tests/test_jack_bot_waiver.py` — blend, monotonicity, injury gating (incl. OUT -> 0), proportionality, reserve/budget clamps, tie-break margin, and `BID_AMOUNT` scaling. All pure / offline.

```
30 passed, 1 warning in 0.26s
```
(waiver + existing jack_bot vorp/draft suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)