### PR TITLE
Evaluator: deterministic draft-slot pinning for candidate bot (#267)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,14 @@ launch-simulator:
 	python3 -m webbrowser http://127.0.0.1:8001/
 	jupyter lab SimulateDraft.ipynb
 
+# Optional: SLOT pins the candidate's 1-based draft slot (reproducible), SEED fixes the
+# surrounding field's order. Unset => today's random draft order. e.g. make evaluate-bot
+# BOT=... YEAR=2025 RUNS=3 SLOT=7 SEED=42
 evaluate-bot:
 	$(MAKE) build-docker
 	DOCKER_HOST="$${DOCKER_HOST:-$$(docker context inspect -f '{{.Endpoints.docker.Host}}' 2>/dev/null)}" \
-		go run ./pkg/cmd/evaluate -bot=$(BOT) -year=$(YEAR) -runs=$(RUNS)
+		go run ./pkg/cmd/evaluate -bot=$(BOT) -year=$(YEAR) -runs=$(RUNS) \
+		$(if $(SLOT),-draft_slot=$(SLOT),) $(if $(SEED),-seed=$(SEED),)
 
 launch-in-season-datasette:
 	pip3 install -r requirements.txt

--- a/pkg/cmd/evaluate/main.go
+++ b/pkg/cmd/evaluate/main.go
@@ -22,6 +22,8 @@ var (
 	dataYear     = flag.Int("year", 2025, "season whose data (season.db) to evaluate against")
 	numTeams     = flag.Int("teams", 14, "number of teams in the league")
 	runs         = flag.Int("runs", 1, "number of independent season simulations")
+	draftSlot    = flag.Int("draft_slot", 0, "1-based draft slot to pin the candidate bot to (0 = random order, the default)")
+	draftSeed    = flag.Int64("seed", 0, "seed for the surrounding field's draft order when -draft_slot is set (reproducible)")
 )
 
 // scratchYear is a throwaway season the engine drafts/replays against so the tracked
@@ -95,11 +97,26 @@ func runOneSeason(ctx context.Context) ([]engine.Standing, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Load-bearing despite the discarded result: this seeds the handler's cached bot
-	// order that runDraft reads, so the draft order is randomized each run. Without it
-	// the draft falls back to id-ascending and bot "0" would always pick first.
-	if _, err := draftHandler.GetBotsInRandomOrder(); err != nil {
-		return nil, err
+	// Seed the handler's cached bot order that runDraft reads. Two paths:
+	//   - draft_slot unset (0): randomized order each run (GetBotsInRandomOrder).
+	//     Load-bearing despite the discarded result; without it the draft falls back to
+	//     id-ascending and bot "0" would always pick first.
+	//   - draft_slot set: pin the candidate to that 1-based slot, with the surrounding
+	//     field seeded so the whole order is reproducible across runs.
+	if *draftSlot == 0 {
+		if _, err := draftHandler.GetBotsInRandomOrder(); err != nil {
+			return nil, err
+		}
+	} else {
+		botsAsc, err := draftHandler.GetBots()
+		if err != nil {
+			return nil, err
+		}
+		ordered, err := engine.OrderBotsWithPinnedSlot(botsAsc, botUnderTestID, *draftSlot, *draftSeed)
+		if err != nil {
+			return nil, err
+		}
+		draftHandler.SetCachedBotOrder(ordered)
 	}
 	draftEngine := engine.NewBotEngine(
 		draftHandler,

--- a/pkg/engine/DraftOrder.go
+++ b/pkg/engine/DraftOrder.go
@@ -1,0 +1,54 @@
+package engine
+
+import (
+	"fmt"
+	"math/rand"
+
+	gamestate "github.com/mitchwebster/botblitz/pkg/gamestate"
+)
+
+// OrderBotsWithPinnedSlot returns the draft order with candidateID placed at the given
+// 1-based slot, while every other bot fills the remaining slots in a seeded-shuffled
+// order. The draft consumes the slice in index order (snake draft), so slot 1 == index 0.
+//
+// It is deterministic and reproducible: the same (bots, candidateID, slot, seed) always
+// yields the same order. This is the pinned counterpart to GameStateHandler's
+// GetBotsInRandomOrder (which uses SQLite RANDOM() and is intentionally non-reproducible).
+//
+// Errors loudly rather than clamping when slot is out of range [1, len(bots)] or when
+// candidateID is not present in bots.
+func OrderBotsWithPinnedSlot(bots []gamestate.Bot, candidateID string, slot int, seed int64) ([]gamestate.Bot, error) {
+	n := len(bots)
+	if n == 0 {
+		return nil, fmt.Errorf("cannot order an empty bot list")
+	}
+	if slot < 1 || slot > n {
+		return nil, fmt.Errorf("draft slot %d out of range [1, %d]", slot, n)
+	}
+
+	// Separate the candidate from the rest, preserving input order for the others so the
+	// seeded shuffle is the only source of variability.
+	others := make([]gamestate.Bot, 0, n-1)
+	var candidate *gamestate.Bot
+	for i := range bots {
+		if bots[i].ID == candidateID {
+			c := bots[i]
+			candidate = &c
+			continue
+		}
+		others = append(others, bots[i])
+	}
+	if candidate == nil {
+		return nil, fmt.Errorf("candidate bot %q not found in bot list", candidateID)
+	}
+
+	// Seeded shuffle of the non-candidate bots so the surrounding field is reproducible.
+	rng := rand.New(rand.NewSource(seed))
+	rng.Shuffle(len(others), func(i, j int) { others[i], others[j] = others[j], others[i] })
+
+	ordered := make([]gamestate.Bot, 0, n)
+	ordered = append(ordered, others[:slot-1]...)
+	ordered = append(ordered, *candidate)
+	ordered = append(ordered, others[slot-1:]...)
+	return ordered, nil
+}

--- a/pkg/engine/DraftOrder_test.go
+++ b/pkg/engine/DraftOrder_test.go
@@ -1,0 +1,126 @@
+package engine
+
+import (
+	"testing"
+
+	gamestate "github.com/mitchwebster/botblitz/pkg/gamestate"
+)
+
+func makeBots(n int) []gamestate.Bot {
+	bots := make([]gamestate.Bot, n)
+	for i := 0; i < n; i++ {
+		bots[i] = gamestate.Bot{ID: itoa(i)}
+	}
+	return bots
+}
+
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	digits := ""
+	for i > 0 {
+		digits = string(rune('0'+i%10)) + digits
+		i /= 10
+	}
+	return digits
+}
+
+func idsOf(bots []gamestate.Bot) []string {
+	out := make([]string, len(bots))
+	for i, b := range bots {
+		out[i] = b.ID
+	}
+	return out
+}
+
+// Candidate lands at the requested 1-based slot, and the full order is identical across
+// repeated calls with the same seed (reproducible-when-set).
+func TestOrderBotsWithPinnedSlot_PinnedAndReproducible(t *testing.T) {
+	bots := makeBots(14)
+	const candidate = "0"
+
+	for _, slot := range []int{1, 7, 14} {
+		first, err := OrderBotsWithPinnedSlot(bots, candidate, slot, 42)
+		if err != nil {
+			t.Fatalf("slot %d: unexpected error: %v", slot, err)
+		}
+		if len(first) != len(bots) {
+			t.Fatalf("slot %d: expected %d bots, got %d", slot, len(bots), len(first))
+		}
+		if got := first[slot-1].ID; got != candidate {
+			t.Fatalf("slot %d: candidate at index %d is %q, want %q", slot, slot-1, got, candidate)
+		}
+
+		// Same inputs => identical order on a repeated call.
+		second, err := OrderBotsWithPinnedSlot(bots, candidate, slot, 42)
+		if err != nil {
+			t.Fatalf("slot %d: unexpected error on repeat: %v", slot, err)
+		}
+		a, b := idsOf(first), idsOf(second)
+		for i := range a {
+			if a[i] != b[i] {
+				t.Fatalf("slot %d: order not reproducible at index %d: %v vs %v", slot, i, a, b)
+			}
+		}
+
+		// Every bot appears exactly once.
+		seen := map[string]bool{}
+		for _, id := range a {
+			if seen[id] {
+				t.Fatalf("slot %d: bot %q appears more than once: %v", slot, id, a)
+			}
+			seen[id] = true
+		}
+		if len(seen) != len(bots) {
+			t.Fatalf("slot %d: expected %d unique bots, got %d", slot, len(bots), len(seen))
+		}
+	}
+}
+
+// Different seeds generally produce different surrounding-field orders while keeping the
+// candidate pinned, confirming the seed actually drives the field.
+func TestOrderBotsWithPinnedSlot_SeedVaries(t *testing.T) {
+	bots := makeBots(14)
+	const candidate = "0"
+
+	a, err := OrderBotsWithPinnedSlot(bots, candidate, 7, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	b, err := OrderBotsWithPinnedSlot(bots, candidate, 7, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if a[6].ID != candidate || b[6].ID != candidate {
+		t.Fatalf("candidate not pinned at slot 7 for both seeds")
+	}
+	same := true
+	ai, bi := idsOf(a), idsOf(b)
+	for i := range ai {
+		if ai[i] != bi[i] {
+			same = false
+			break
+		}
+	}
+	if same {
+		t.Fatalf("expected different field orders for different seeds, got identical: %v", ai)
+	}
+}
+
+func TestOrderBotsWithPinnedSlot_Errors(t *testing.T) {
+	bots := makeBots(14)
+
+	if _, err := OrderBotsWithPinnedSlot(bots, "0", 0, 0); err == nil {
+		t.Fatal("expected error for slot 0 (below range)")
+	}
+	if _, err := OrderBotsWithPinnedSlot(bots, "0", 15, 0); err == nil {
+		t.Fatal("expected error for slot 15 (above range)")
+	}
+	if _, err := OrderBotsWithPinnedSlot(bots, "missing", 7, 0); err == nil {
+		t.Fatal("expected error for candidate not present in bot list")
+	}
+	if _, err := OrderBotsWithPinnedSlot(nil, "0", 1, 0); err == nil {
+		t.Fatal("expected error for empty bot list")
+	}
+}

--- a/pkg/gamestate/handler.go
+++ b/pkg/gamestate/handler.go
@@ -120,6 +120,14 @@ func (handler *GameStateHandler) GetBotsInRandomOrder() ([]Bot, error) {
 	return handler.cachedBotList, nil
 }
 
+// SetCachedBotOrder overrides the cached bot list with an explicit, caller-determined
+// order. The draft consumes GetBots() in slice order, so this fixes the draft order
+// deterministically (used by the evaluator to pin the candidate's draft slot). This is the
+// reproducible counterpart to GetBotsInRandomOrder.
+func (handler *GameStateHandler) SetCachedBotOrder(bots []Bot) {
+	handler.cachedBotList = bots
+}
+
 func (handler *GameStateHandler) GetPastMatchups(currentWeek int) ([]Matchup, error) {
 	var matchups []Matchup
 	result := handler.db.Where("week < ?", currentWeek).Find(&matchups)


### PR DESCRIPTION
Closes #267

## What
Additive Go engine enhancement: the evaluator can now pin the candidate bot's draft slot deterministically instead of relying on randomized order.

## How
- `engine.OrderBotsWithPinnedSlot(bots, candidateID, slot, seed)` — pure, testable: candidate at the 1-based slot, surrounding field seeded-shuffled (reproducible). Errors loudly on out-of-range slot or unknown candidate.
- `gamestate.SetCachedBotOrder` — applies the pinned order to the handler's cached bot list (snake draft consumes it in order).
- `pkg/cmd/evaluate` flags: `-draft_slot` (0 = unchanged random default) and `-seed`. Makefile `evaluate-bot` passes optional `SLOT`/`SEED` through.

## Default behavior unchanged
When `-draft_slot` is unset (0), the evaluator takes the existing `GetBotsInRandomOrder` path exactly as before.

## Tests
`pkg/engine` unit tests cover pin position (slots 1/7/14), reproducibility across repeated calls, seed-driven field variance, and error cases. `go test ./...` in `pkg/engine` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)